### PR TITLE
Add pyarrow to dependencies 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "litellm",
     "dask",
     "pandas"
+    "pyarrow"
 ]
 
 [project.urls]


### PR DESCRIPTION
This pull request adds the pyarrow package to the dependencies list in pyproject.toml. 
Fixed pyarrow ModuleNotFoundError when running quickstart.