### PR TITLE
Add HuggingFace/Gemini Subclasses; Fix map_partitions Meta Handling

### DIFF
--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -215,8 +215,10 @@ class Filter(Op):
                 self.serialized_input_column,
             ),
         )
+        meta_dict = df._meta.dtypes.to_dict()
+        meta_dict[self.llm_output_column] = "object"
         llm_outputs = df.map_partitions(
-            partial(llm_inference, llm, self.llm_output_column, self.prompt_column)
+            partial(llm_inference, llm, self.llm_output_column, self.prompt_column),meta=meta_dict
         )
         results = llm_outputs.map_partitions(
             partial(

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -215,8 +215,10 @@ class Map(Op):
                 self.output_fields,
             ),
         )
+        meta_dict = df._meta.dtypes.to_dict()
+        meta_dict[self.llm_output_column] = "object"
         df = df.map_partitions(
-            partial(llm_inference, llm, self.llm_output_column, self.prompt_column)
+            partial(llm_inference, llm, self.llm_output_column, self.prompt_column),meta=meta_dict
         )
 
         input_cols = list(df._meta.columns)

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -100,3 +100,23 @@ class Gemini(LLM):
         kwargs.update(gemini_params)
 
         super().__init__(model_name=gemini_model, **kwargs)
+
+class HuggingFace(LLM):
+        def __init__(
+            self,
+            model_name: str,
+            api_base: Optional[str] = None,
+            api_key: Optional[str] = None,
+            **kwargs,
+        ) -> None:
+         
+            
+            hf_model = f"huggingface/{model_name}"
+            hf_params = {
+                "api_base": api_base,
+                "api_key": api_key,
+            }
+            hf_params = {k: v for k, v in hf_params.items() if v is not None}
+
+            kwargs.update(hf_params)
+            super().__init__(model_name=hf_model, **kwargs)

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -80,3 +80,23 @@ class Azure(LLM):
 
         kwargs.update(azure_params)
         super().__init__(model_name=azure_model, **kwargs)
+
+class Gemini(LLM):
+    def __init__(
+        self,
+        model_name: str = "gemini/gemini-1.5-pro",
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        gemini_model = model_name if model_name.startswith("gemini/") else f"gemini/{model_name}"
+
+        gemini_params = {
+            "api_key": api_key,
+            "api_base": api_base,
+        }
+
+        gemini_params = {k: v for k, v in gemini_params.items() if v is not None}
+        kwargs.update(gemini_params)
+
+        super().__init__(model_name=gemini_model, **kwargs)

--- a/datatune/llm/openapibatchutils.py
+++ b/datatune/llm/openapibatchutils.py
@@ -1,0 +1,64 @@
+import json
+import os
+import dask
+from dask import delayed
+
+from concurrent.futures import ThreadPoolExecutor
+import pandas as pd
+from typing import List
+
+
+def export_openai_jsonl(prompts:List[str],model_name:str,input_file: str,system_prompt: str = "You are a helpful assistant."):
+    
+
+    with open(input_file, 'w', encoding='utf-8') as f:
+        for i, prompt in enumerate(prompts, start=1):
+            item = {
+                "custom_id": f"request-{i}",
+                "method": "POST",
+                "url": "/v1/chat/completions",
+                "body": {
+                    "model":model_name,
+                    "messages": [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": prompt}
+                    ],
+                    "max_tokens": 1000
+                }
+            }
+            json.dump(item, f)
+            f.write("\n")
+    return input_file
+
+def extract_contents_from_jsonl(jsonl_path: str) -> list[str]:
+    contents = []
+    with open(jsonl_path, "r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                data = json.loads(line)
+                content = data["response"]["body"]["choices"][0]["message"]["content"]
+                contents.append(content)
+            except (KeyError, IndexError, json.JSONDecodeError) as e:
+                continue
+    return contents
+
+def multiple_jsonl_export(prompts:List[str],model_name:str,no_of_rows:int,batch_size:int): 
+    delayed_export = delayed(export_openai_jsonl)
+    results = []
+
+    for i,start in enumerate(range(0, no_of_rows, batch_size)):
+        batch_prompts = prompts[start:start+batch_size]
+        task = delayed_export(batch_prompts, model_name, input_file=f"batch_{i}.jsonl")
+        results.append(task)
+    result = dask.compute(*results)
+    return result
+
+
+def multiple_jsonl_extract(jsonl_files: list[str]) ->list[str]:
+
+    all_contents = []
+    with ThreadPoolExecutor() as executor:
+        results = executor.map(extract_contents_from_jsonl, jsonl_files)
+        for contents in results:
+            all_contents.extend(contents)
+    return all_contents


### PR DESCRIPTION
## Add support for Gemini and HuggingFace LLM providers

### Summary
This PR adds two new `LLM` subclasses to support additional model providers:

- `Gemini`: Google's Gemini models
- `HuggingFace`: Models served via Hugging Face Inference API

##  Fix unintended API calls during schema inference

### Problem
Dask was calling `llm_inference()` with dummy data to infer the output schema, which triggered **real** LLM API calls during `map_partitions`.

### Fix
Added an explicit `meta=` argument:
```python
meta_dict = df._meta.dtypes.to_dict()
meta_dict[self.llm_output_column] = "object"
df = df.map_partitions(
    partial(llm_inference, llm, self.llm_output_column, self.prompt_column),
    meta=meta_dict
)
```

Fixes #34 
Fixes #35  