### PR TITLE
Add BatchAPI subclass to support OpenAI Batch API 

### DIFF
--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -215,8 +215,10 @@ class Filter(Op):
                 self.serialized_input_column,
             ),
         )
+        meta_dict = df._meta.dtypes.to_dict()
+        meta_dict[self.llm_output_column] = "object"
         llm_outputs = df.map_partitions(
-            partial(llm_inference, llm, self.llm_output_column, self.prompt_column)
+            partial(llm_inference, llm, self.llm_output_column, self.prompt_column),meta=meta_dict
         )
         results = llm_outputs.map_partitions(
             partial(

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -215,8 +215,10 @@ class Map(Op):
                 self.output_fields,
             ),
         )
+        meta_dict = df._meta.dtypes.to_dict()
+        meta_dict[self.llm_output_column] = "object"
         df = df.map_partitions(
-            partial(llm_inference, llm, self.llm_output_column, self.prompt_column)
+            partial(llm_inference, llm, self.llm_output_column, self.prompt_column),meta=meta_dict
         )
 
         input_cols = list(df._meta.columns)

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Union
 import asyncio
 import litellm
-from datatune.llm.openai_batch_utils import multiple_jsonl_extract,multiple_jsonl_export
+from datatune.llm.openai_batch_utils import generate_jsonl_batches,parse_jsonl_files,token_count_jsonl
 
 
 class LLM:
@@ -141,6 +141,13 @@ class Huggingface(LLM):
         super().__init__(model_name=self.model_name, **kwargs)        
 
 class OpenAIBatchAPI(LLM):
+
+    TOKEN_LIMIT = 2000000
+    enqued_tokens = 0
+    lock = asyncio.Lock()
+
+
+
     def __init__(
             self,
             model_name:str = "gpt-3.5-turbo",
@@ -150,81 +157,105 @@ class OpenAIBatchAPI(LLM):
         kwargs.update({"api_key": api_key})
         super().__init__(model_name=model_name, **kwargs)
 
+        self.batch_size = 6000
+        
+
+
     async def process_batch(self,file_path: str, batch_id: int):
-        with open (file_path,"rb") as f:
-            file_bytes = f.read()
-        file_obj = await litellm.acreate_file(
-            file=file_bytes,
-            purpose="batch",
-            custom_llm_provider="openai",
-        )
-        print(f"[{file_path}] Uploaded as File ID: {file_obj.id}")
-
-        create_batch_response = await litellm.acreate_batch(
-            completion_window="24h",
-            endpoint="/v1/chat/completions",
-            input_file_id=file_obj.id,
-            custom_llm_provider="openai",
-            metadata={"batch": f"batch-{batch_id}"},
-        )
-        print(f"[{file_path}] Batch Created: {create_batch_response.id}")
-
-        # Polling loop
-        MAX_WAIT_TIME = 300
-        POLL_INTERVAL = 5
-        MAX_FAILURE_RETRIES = 100
-
-        waited = 0
-        failure_count = 0
-
+        """
+        Uploads a single JSONL file, creates a batch request, waits for completion,
+        downloads and saves the output JSONL.
+        """
+        tokens = token_count_jsonl(file_path,self.model_name)
         while True:
-            retrieved_batch = await litellm.aretrieve_batch(
-                batch_id=create_batch_response.id,
+            async with self.lock:
+                if self.enqued_tokens + tokens < self.TOKEN_LIMIT:
+                    self.enqued_tokens += tokens
+                    break
+            print(f"[{file_path}] Waiting for token capacity...")
+            await asyncio.sleep(5)
+        try:
+            # Upload file to OpenAI
+            with open (file_path,"rb") as f:
+                file_bytes = f.read()
+            file_obj = await litellm.acreate_file(
+                file=file_bytes,
+                purpose="batch",
+                custom_llm_provider="openai",
+            )
+            print(f"[{file_path}] Uploaded as File ID: {file_obj.id}")
+
+            # Submit batch job
+            create_batch_response = await litellm.acreate_batch(
+                completion_window="24h",
+                endpoint="/v1/chat/completions",
+                input_file_id=file_obj.id,
+                custom_llm_provider="openai",
+                metadata={"batch": f"batch-{batch_id}"},
+            )
+            print(f"[{file_path}] Batch Created: {create_batch_response.id}")
+
+            # Polling loop
+            MAX_WAIT_TIME = 300000000
+            POLL_INTERVAL = 30
+            MAX_FAILURE_RETRIES = 100
+
+            waited = 0
+            failure_count = 0
+
+            while True:
+                retrieved_batch = await litellm.aretrieve_batch(
+                    batch_id=create_batch_response.id,
+                    custom_llm_provider="openai"
+                )
+                status = retrieved_batch.status
+                print(f"[{file_path}]  Batch status: {status}")
+
+                if status == "completed" and retrieved_batch.output_file_id:
+                    print(f"[{file_path}] ✅ Completed. Output File ID: {retrieved_batch.output_file_id}")
+                    break
+
+                elif status in ["failed", "cancelled", "expired"]:
+                    failure_count += 1
+                    print(f"[{file_path}] ⚠️ Batch in failed state ({status}), retrying {failure_count}/{MAX_FAILURE_RETRIES}")
+                    if failure_count >= MAX_FAILURE_RETRIES:
+                        raise RuntimeError(f"[{file_path}] ❌ Batch failed with status: {status} after {MAX_FAILURE_RETRIES} retries")
+
+                await asyncio.sleep(POLL_INTERVAL)
+                waited += POLL_INTERVAL
+                if waited > MAX_WAIT_TIME:
+                    raise TimeoutError(f"[{file_path}] ❌ Timed out waiting for batch to complete.")
+
+
+            # Download and save the output file
+            file_content = await litellm.afile_content(
+                file_id=retrieved_batch.output_file_id,
                 custom_llm_provider="openai"
             )
-            status = retrieved_batch.status
-            print(f"[{file_path}]  Batch status: {status}")
+            output_bytes = await file_content.aread()
+            output_str = output_bytes.decode("utf-8")
 
-            if status == "completed" and retrieved_batch.output_file_id:
-                print(f"[{file_path}] ✅ Completed. Output File ID: {retrieved_batch.output_file_id}")
-                break
-
-            elif status in ["failed", "cancelled", "expired"]:
-                failure_count += 1
-                print(f"[{file_path}] ⚠️ Batch in failed state ({status}), retrying {failure_count}/{MAX_FAILURE_RETRIES}")
-                if failure_count >= MAX_FAILURE_RETRIES:
-                    raise RuntimeError(f"[{file_path}] ❌ Batch failed with status: {status} after {MAX_FAILURE_RETRIES} retries")
-
-            await asyncio.sleep(POLL_INTERVAL)
-            waited += POLL_INTERVAL
-            if waited > MAX_WAIT_TIME:
-                raise TimeoutError(f"[{file_path}] ❌ Timed out waiting for batch to complete.")
-
-
-        # Download and save the output file
-        file_content = await litellm.afile_content(
-            file_id=retrieved_batch.output_file_id,
-            custom_llm_provider="openai"
-        )
-        output_bytes = await file_content.aread()
-        output_str = output_bytes.decode("utf-8")
-
-        with open(f"response_{batch_id}.jsonl", "w", encoding='utf-8') as f:
-            f.write(output_str)
-        print(f"[{file_path}]  Output saved to response_{batch_id}.jsonl")
+            with open(f"response_{batch_id}.jsonl", "w", encoding='utf-8') as f:
+                f.write(output_str)
+            print(f"[{file_path}]  Output saved to response_{batch_id}.jsonl")
+        finally:
+            async with self.lock:
+                self.enqued_tokens -= tokens
 
     async def main(self):
+        """
+        Launches parallel batch processing and gathers all results.
+        """
+
         tasks = [self.process_batch(file_path, i) for i, file_path in enumerate(self.input_files)]
         await asyncio.gather(*tasks)
-        ret = multiple_jsonl_extract([f"response_{i}.jsonl" for i in range (0,self.no_of_rows,self.batch_size)])
+        ret = parse_jsonl_files([f"response_{i}.jsonl" for i,_ in enumerate(range (0, self.no_of_rows, self.batch_size))])
         return ret
 
 
     def __call__(self, prompt:List[str]) -> List[str]:
-        """Always return a list of strings, regardless of input type"""
-        self.no_of_rows =len(prompt)
-        self.batch_size = 50000
-        self.input_files = multiple_jsonl_export(prompt,self.model_name,self.no_of_rows,self.batch_size)
+        self.no_of_rows = len(prompt)
+        self.input_files = generate_jsonl_batches(prompt, self.model_name, self.no_of_rows, self.batch_size)
         print("Input JSON files created.")
         
         return asyncio.run(self.main())

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -157,7 +157,7 @@ class OpenAIBatchAPI(LLM):
         kwargs.update({"api_key": api_key})
         super().__init__(model_name=model_name, **kwargs)
 
-        self.batch_size = 6000
+        self.batch_size = 20
         
 
 

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -1,4 +1,7 @@
 from typing import List, Optional, Union
+import asyncio
+import litellm
+from datatune.llm.openai_batch_utils import multiple_jsonl_extract,multiple_jsonl_export
 
 
 class LLM:
@@ -80,3 +83,92 @@ class Azure(LLM):
 
         kwargs.update(azure_params)
         super().__init__(model_name=azure_model, **kwargs)
+
+class OpenAIBatchAPI(LLM):
+    def __init__(
+            self,
+            model_name:str = "gpt-3.5-turbo",
+            api_key:Optional[str] = None,
+            **kwargs
+    ):
+        kwargs.update({"api_key": api_key})
+        super().__init__(model_name=model_name, **kwargs)
+
+    async def process_batch(self,file_path: str, batch_id: int):
+        with open (file_path,"rb") as f:
+            file_bytes = f.read()
+        file_obj = await litellm.acreate_file(
+            file=file_bytes,
+            purpose="batch",
+            custom_llm_provider="openai",
+        )
+        print(f"[{file_path}] Uploaded as File ID: {file_obj.id}")
+
+        create_batch_response = await litellm.acreate_batch(
+            completion_window="24h",
+            endpoint="/v1/chat/completions",
+            input_file_id=file_obj.id,
+            custom_llm_provider="openai",
+            metadata={"batch": f"batch-{batch_id}"},
+        )
+        print(f"[{file_path}] Batch Created: {create_batch_response.id}")
+
+        # Polling loop
+        MAX_WAIT_TIME = 300
+        POLL_INTERVAL = 5
+        MAX_FAILURE_RETRIES = 100
+
+        waited = 0
+        failure_count = 0
+
+        while True:
+            retrieved_batch = await litellm.aretrieve_batch(
+                batch_id=create_batch_response.id,
+                custom_llm_provider="openai"
+            )
+            status = retrieved_batch.status
+            print(f"[{file_path}]  Batch status: {status}")
+
+            if status == "completed" and retrieved_batch.output_file_id:
+                print(f"[{file_path}] ✅ Completed. Output File ID: {retrieved_batch.output_file_id}")
+                break
+
+            elif status in ["failed", "cancelled", "expired"]:
+                failure_count += 1
+                print(f"[{file_path}] ⚠️ Batch in failed state ({status}), retrying {failure_count}/{MAX_FAILURE_RETRIES}")
+                if failure_count >= MAX_FAILURE_RETRIES:
+                    raise RuntimeError(f"[{file_path}] ❌ Batch failed with status: {status} after {MAX_FAILURE_RETRIES} retries")
+
+            await asyncio.sleep(POLL_INTERVAL)
+            waited += POLL_INTERVAL
+            if waited > MAX_WAIT_TIME:
+                raise TimeoutError(f"[{file_path}] ❌ Timed out waiting for batch to complete.")
+
+
+        # Download and save the output file
+        file_content = await litellm.afile_content(
+            file_id=retrieved_batch.output_file_id,
+            custom_llm_provider="openai"
+        )
+        output_bytes = await file_content.aread()
+        output_str = output_bytes.decode("utf-8")
+
+        with open(f"response_{batch_id}.jsonl", "w", encoding='utf-8') as f:
+            f.write(output_str)
+        print(f"[{file_path}]  Output saved to response_{batch_id}.jsonl")
+
+    async def main(self):
+        tasks = [self.process_batch(file_path, i) for i, file_path in enumerate(self.input_files)]
+        await asyncio.gather(*tasks)
+        ret = multiple_jsonl_extract([f"response_{i}.jsonl" for i in range (0,self.no_of_rows,self.batch_size)])
+        return ret
+
+
+    def __call__(self, prompt:List[str]) -> List[str]:
+        """Always return a list of strings, regardless of input type"""
+        self.no_of_rows =len(prompt)
+        self.batch_size = 50000
+        self.input_files = multiple_jsonl_export(prompt,self.model_name,self.no_of_rows,self.batch_size)
+        print("Input JSON files created.")
+        
+        return asyncio.run(self.main())

--- a/datatune/llm/openai_batch_utils.py
+++ b/datatune/llm/openai_batch_utils.py
@@ -1,15 +1,23 @@
 import json
-import os
 import dask
 from dask import delayed
-
 from concurrent.futures import ThreadPoolExecutor
-import pandas as pd
 from typing import List
+from litellm import token_counter
 
+def generate_jsonl_file(prompts:List[str],model_name:str,input_file: str,system_prompt: str = "You are a helpful assistant.")->str:
+    """
+    Creates a JSONL file with OpenAI-style chat completion requests for a list of prompts.
 
-def export_openai_jsonl(prompts:List[str],model_name:str,input_file: str,system_prompt: str = "You are a helpful assistant."):
-    
+    Args:
+        prompts (List[str]): List of user prompts to be formatted into JSONL entries.
+        model_name (str): Name of the language model to be used in the request.
+        input_file (str): Path to the output JSONL file.
+        system_prompt (str, optional): The system instruction to include in each request. Defaults to a generic assistant role.
+
+    Returns:
+        str: Path to the created JSONL file.
+    """
 
     with open(input_file, 'w', encoding='utf-8') as f:
         for i, prompt in enumerate(prompts, start=1):
@@ -30,7 +38,17 @@ def export_openai_jsonl(prompts:List[str],model_name:str,input_file: str,system_
             f.write("\n")
     return input_file
 
-def extract_contents_from_jsonl(jsonl_path: str) -> list[str]:
+def parse_jsonl(jsonl_path: str) -> List[str]:
+    """
+    Parses a JSONL file containing LLM response data and extracts the message content.
+
+    Args:
+        jsonl_path (str): Path to the JSONL file containing LLM responses.
+
+    Returns:
+        List[str]: A list of extracted message contents from the LLM responses.
+    """
+
     contents = []
     with open(jsonl_path, "r", encoding="utf-8") as f:
         for line in f:
@@ -42,8 +60,21 @@ def extract_contents_from_jsonl(jsonl_path: str) -> list[str]:
                 continue
     return contents
 
-def multiple_jsonl_export(prompts:List[str],model_name:str,no_of_rows:int,batch_size:int): 
-    delayed_export = delayed(export_openai_jsonl)
+def generate_jsonl_batches(prompts:List[str], model_name:str, no_of_rows:int, batch_size:int)->List[str]: 
+    """
+    Splits a list of prompts into batches and creates a JSONL file for each batch using generate_json_file and Dask.
+
+    Args:
+        prompts (List[str]): Full list of user prompts.
+        model_name (str): Model to use for all prompts.
+        no_of_rows (int): Total number of prompts to consider.
+        batch_size (int): Number of prompts per JSONL file.
+
+    Returns:
+        List[str]: List of paths to the created JSONL batch files.
+    """
+
+    delayed_export = delayed(generate_jsonl_file)
     results = []
 
     for i,start in enumerate(range(0, no_of_rows, batch_size)):
@@ -51,14 +82,39 @@ def multiple_jsonl_export(prompts:List[str],model_name:str,no_of_rows:int,batch_
         task = delayed_export(batch_prompts, model_name, input_file=f"batch_{i}.jsonl")
         results.append(task)
     result = dask.compute(*results)
-    return result
+    return list(result)
 
 
-def multiple_jsonl_extract(jsonl_files: list[str]) ->list[str]:
+def parse_jsonl_files(jsonl_files: List[str]) ->List[str]:
+    """
+    Parses multiple JSONL files in parallel and collects all extracted LLM responses.
+
+    Args:
+        jsonl_files (list[str]): List of paths to JSONL files containing LLM responses.
+
+    Returns:
+        List[str]:List of all extracted message contents from all JSONL files.
+    """
 
     all_contents = []
     with ThreadPoolExecutor() as executor:
-        results = executor.map(extract_contents_from_jsonl, jsonl_files)
+        results = executor.map(parse_jsonl, jsonl_files)
         for contents in results:
             all_contents.extend(contents)
     return all_contents
+
+def token_count_jsonl(jsonl_path:str,model_name:str)->int:
+    with open(jsonl_path,"r",encoding="utf-8") as f:
+        token_count = 0
+        for line in f:
+            try:
+                data= json.loads(line)
+                token_count+= token_counter(model=model_name,messages=data["body"]["messages"])
+            except (KeyError, IndexError, json.JSONDecodeError) as e:
+                continue
+    return token_count    
+                
+
+                
+
+

--- a/datatune/llm/openai_batch_utils.py
+++ b/datatune/llm/openai_batch_utils.py
@@ -104,6 +104,16 @@ def parse_jsonl_files(jsonl_files: List[str]) ->List[str]:
     return all_contents
 
 def token_count_jsonl(jsonl_path:str,model_name:str)->int:
+    """
+    Counts the number of tokens in an input jsonl file.
+
+    Args:
+        jsonl_path (str): Path to input jsonl file.
+
+    Returns:
+        int: Number of tokens.
+    """
+
     with open(jsonl_path,"r",encoding="utf-8") as f:
         token_count = 0
         for line in f:

--- a/datatune/llm/openai_batch_utils.py
+++ b/datatune/llm/openai_batch_utils.py
@@ -1,0 +1,64 @@
+import json
+import os
+import dask
+from dask import delayed
+
+from concurrent.futures import ThreadPoolExecutor
+import pandas as pd
+from typing import List
+
+
+def export_openai_jsonl(prompts:List[str],model_name:str,input_file: str,system_prompt: str = "You are a helpful assistant."):
+    
+
+    with open(input_file, 'w', encoding='utf-8') as f:
+        for i, prompt in enumerate(prompts, start=1):
+            item = {
+                "custom_id": f"request-{i}",
+                "method": "POST",
+                "url": "/v1/chat/completions",
+                "body": {
+                    "model":model_name,
+                    "messages": [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": prompt}
+                    ],
+                    "max_tokens": 1000
+                }
+            }
+            json.dump(item, f)
+            f.write("\n")
+    return input_file
+
+def extract_contents_from_jsonl(jsonl_path: str) -> list[str]:
+    contents = []
+    with open(jsonl_path, "r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                data = json.loads(line)
+                content = data["response"]["body"]["choices"][0]["message"]["content"]
+                contents.append(content)
+            except (KeyError, IndexError, json.JSONDecodeError) as e:
+                continue
+    return contents
+
+def multiple_jsonl_export(prompts:List[str],model_name:str,no_of_rows:int,batch_size:int): 
+    delayed_export = delayed(export_openai_jsonl)
+    results = []
+
+    for i,start in enumerate(range(0, no_of_rows, batch_size)):
+        batch_prompts = prompts[start:start+batch_size]
+        task = delayed_export(batch_prompts, model_name, input_file=f"batch_{i}.jsonl")
+        results.append(task)
+    result = dask.compute(*results)
+    return result
+
+
+def multiple_jsonl_extract(jsonl_files: list[str]) ->list[str]:
+
+    all_contents = []
+    with ThreadPoolExecutor() as executor:
+        results = executor.map(extract_contents_from_jsonl, jsonl_files)
+        for contents in results:
+            all_contents.extend(contents)
+    return all_contents


### PR DESCRIPTION
##  Add `OpenAIBatchAPI` subclass to `LLM` interface

### Summary

This PR adds a new subclass, `OpenAIBatchAPI`, to the existing `LLM` interface. The `OpenAIBatchAPI` integrates with the OpenAI Batch API via LiteLLM, enabling efficient asynchronous processing of large volumes of prompts through batch jobs.

### Key Changes

- Introduced `OpenAIBatchAPI(LLM)` class
- Added new module: `openai_batch_utils.py`
  - Handles:
    - Generating input JSONL files from prompt data
    - Parsing output content from response JSONL files
    - Counts tokens in input JSONL files
   
##  Fix unintended API calls during schema inference

### Problem

Dask was calling `llm_inference()` with dummy data during schema inference to determine the output structure. This caused **real LLM API calls** to be triggered unintentionally during `map_partitions()`.

### Fix

Added an explicit `meta=` argument to prevent Dask from executing the function on sample data:

```python
meta_dict = df._meta.dtypes.to_dict()
meta_dict[self.llm_output_column] = "object"

df = df.map_partitions(
    partial(llm_inference, llm, self.llm_output_column, self.prompt_column),
    meta=meta_dict
)

