### PR TITLE
Process multiple rows in a single API call

### DIFF
--- a/datatune/__init__.py
+++ b/datatune/__init__.py
@@ -1,9 +1,10 @@
 from datatune.core.map import Map
-from datatune.core.filter import Filter
+from datatune.core.filter import Filter, BatchedFilter
 from datatune.core.op import finalize
 
 __all__ = [
     "Map",
     "Filter",
+    "BatchedFilter",
     "finalize"
 ]

--- a/datatune/__init__.py
+++ b/datatune/__init__.py
@@ -1,5 +1,6 @@
 from datatune.core.map import Map
 from datatune.core.filter import Filter, BatchedFilter
+from datatune.core.map import BatchedMap
 from datatune.core.op import finalize
 
 __all__ = [
@@ -7,4 +8,5 @@ __all__ = [
     "Filter",
     "BatchedFilter",
     "finalize"
+    "BatchedMap"
 ]

--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -224,8 +224,10 @@ class Filter(Op):
                 self.serialized_input_column,
             ),
         )
+        meta_dict = df._meta.dtypes.to_dict()
+        meta_dict[self.llm_output_column] = "object"
         llm_outputs = df.map_partitions(
-            partial(llm_inference, llm, self.llm_output_column, self.prompt_column)
+            partial(llm_inference, llm, self.llm_output_column, self.prompt_column),meta=meta_dict
         )
         results = llm_outputs.map_partitions(
             partial(

--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -232,10 +232,13 @@ class Filter(Op):
         llm_outputs = df.map_partitions(
             partial(llm_inference, llm, self.llm_output_column, self.prompt_column),meta=meta_dict
         )
+        meta = llm_outputs._meta.copy()
+        meta[self.result_column] = -1       
+        meta[ERRORED_COLUMN] = False      
         results = llm_outputs.map_partitions(
             partial(
                 parse_filter_output_as_int, self.result_column, self.llm_output_column
-            ),
+            ),meta=meta
         )
         return results.map_partitions(
             partial(delete_rows, self.result_column, self.on_error),

--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -94,17 +94,13 @@ def parse_filter_output(output: Union[str, Exception], err: bool = False) -> Opt
     match = re.search(r"{.*}",output,re.DOTALL)
     dict_str = match.group()
     output_dict = ast.literal_eval(dict_str)
-    output = str(next(reversed(output_dict.values())))
+    output = output_dict.get("filter", None)
     
-    
-    
-    if output.lower() == "true":
-        return True
-    elif output.lower() == 'false':
-        return False
+    if isinstance(output, bool):
+        return output
     elif err:
         raise ValueError(
-            f"Invalid response from LLM: {output}. Expected 'TRUE' or 'FALSE'."
+            f"Invalid response from LLM: {output}. Expected boolean True or False."
         )
     else:
         return None

--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -53,6 +53,21 @@ def filter_prompt(
     return df
 
 def llm_batch_inference(llm: Callable, llm_output_column: str, prompt: str, serialized_input_column: str, df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Creates the filtering prompt, prefix and suffix to be prepended and appended to a batched prompt respectively.
+    The LLM is called with each row's serialized input and its response is stored in a new column.
+
+    Args:
+        llm (Callable): A callable LLM function that accepts (input_rows, prefix, prompt, suffix).
+        llm_output_column (str): Name of the column to store the LLM responses.
+        prompt (str): Base Filter prompt
+        serialized_input_column (str): Name of the column containing serialized input data per row.
+        df (pd.DataFrame): Input DataFrame.
+    
+    Returns:
+        pd.DataFrame: The input DataFrame with an additional column (`llm_output_column`)
+        containing the LLM's responses.
+    """
     prefix = (
         f"You are filtering a dataset. Your task is to determine whether each data record should be KEPT or REMOVED based on the filtering criteria below.{os.linesep}"
         f"Return the entire input data record with an added key called 'filter' with value either True to KEEP the record or False to REMOVE it.{os.linesep}{os.linesep}"

--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -39,13 +39,13 @@ def filter_prompt(
     """
     filtering_context = (
         f"You are filtering a dataset. Your task is to determine whether each data record should be KEPT or REMOVED based on the filtering criteria below.{os.linesep}"
-        f"Return the entire data record with an added key called filter whose value is either TRUE to KEEP the record or FALSE to REMOVE it.{os.linesep}{os.linesep}"
+        f"Return the entire input data record with an added key called filter whose value is either TRUE to KEEP the record or FALSE to REMOVE it.{os.linesep}{os.linesep}"
         f"FILTERING CRITERIA:{os.linesep}{prompt}{os.linesep}{os.linesep}"
         f"DATA RECORD TO EVALUATE:{os.linesep}"
     )
     instructions = (
         f"{os.linesep}{os.linesep}"
-        f"DECISION: Respond with only 'TRUE' (to keep this record) or 'FALSE' (to remove this record). "
+        f"DECISION: Respond with the entire input data record with added key called filter with value either 'TRUE' (to keep this record) or 'FALSE' (to remove this record). "
         f"No explanations or additional text."
     )
     df[prompt_column] = filtering_context + df[serialized_input_column] + instructions

--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -5,7 +5,7 @@ import pandas as pd
 import os
 from datatune.core.constants import DELETED_COLUMN, ERRORED_COLUMN
 import logging
-
+import ast
 
 def input_as_string(serialized_input_column: str, df: pd.DataFrame) -> pd.DataFrame:
     """
@@ -39,7 +39,7 @@ def filter_prompt(
     """
     filtering_context = (
         f"You are filtering a dataset. Your task is to determine whether each data record should be KEPT or REMOVED based on the filtering criteria below.{os.linesep}"
-        f"Return TRUE to KEEP the record, FALSE to REMOVE it.{os.linesep}{os.linesep}"
+        f"Return the entire data record with an added key called filter whose value is either TRUE to KEEP the record or FALSE to REMOVE it.{os.linesep}{os.linesep}"
         f"FILTERING CRITERIA:{os.linesep}{prompt}{os.linesep}{os.linesep}"
         f"DATA RECORD TO EVALUATE:{os.linesep}"
     )
@@ -90,7 +90,10 @@ def parse_filter_output(output: Union[str, Exception], err: bool = False) -> Opt
         logging.error(f"LLM error: {output}")
         return None
     
-    output = output.strip().upper()
+    output = ast.literal_eval(output)
+    value = next(reversed(output.values()))
+    output = str(value)
+    
     
     if output.lower() == "true":
         return True

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -91,7 +91,7 @@ def parse_llm_output(llm_output: Union[str, Exception], no_cols:int) -> Union[Di
         match = re.search(r"{.*}",llm_output,re.DOTALL)
         dict_str = match.group()
         ret = ast.literal_eval(dict_str)
-       # ret = dict(list(dict_output.items()))
+        
         if not isinstance(ret, dict):
             raise ValueError(f"Expected a dictionary, got {type(ret)}")
         return ret

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -54,6 +54,21 @@ def map_prompt(
     return df
 
 def llm_batch_inference(llm: Callable, llm_output_column: str, prompt: str, serialized_input_column: str, expected_new_fields:List[str], df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Creates the mapping prompt, prefix and suffix to be prepended and appended to a batched prompt respectively.
+    The LLM is called with each row's serialized input and its response is stored in a new column.
+
+    Args:
+        llm (Callable): A callable LLM function that accepts (input_rows, prefix, prompt, suffix).
+        llm_output_column (str): Name of the column to store the LLM responses.
+        prompt (str): Base Map prompt
+        serialized_input_column (str): Name of the column containing serialized input data per row.
+        df (pd.DataFrame): Input DataFrame.
+    
+    Returns:
+        pd.DataFrame: The input DataFrame with an additional column (`llm_output_column`)
+        containing the LLM's responses.
+    """
     prefix = (
         f"Map and transform the input according to the mapping criteria below.{os.linesep}"
         f""" Replace or Create new fields or values as per the prompt.

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -219,7 +219,7 @@ class Map(Op):
             ),
         )
         meta_dict = df._meta.dtypes.to_dict()
-        meta_dict[self.llm_output_column] = "object"
+        meta_dict[self.llm_output_column] = str
         df = df.map_partitions(
             partial(llm_inference, llm, self.llm_output_column, self.prompt_column),meta=meta_dict
         )

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -215,8 +215,10 @@ class Map(Op):
                 self.output_fields,
             ),
         )
+        meta_dict = df._meta.dtypes.to_dict()
+        meta_dict[self.llm_output_column] = "object"
         df = df.map_partitions(
-            partial(llm_inference, llm, self.llm_output_column, self.prompt_column)
+            partial(llm_inference, llm, self.llm_output_column, self.prompt_column),meta=meta_dict
         )
 
         input_cols = list(df._meta.columns)

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -47,7 +47,7 @@ def map_prompt(
     Map and transform the above input according to the above prompt.
     Replace or Create new fields or values as per the prompt.
     {f"Expected new fields: {expected_new_fields}." if expected_new_fields else ""}
-    Your response MUST be a valid Python dictionary in the format: {{key1: value1, key2: value2, ...}} with added keys of expected new fields if any.
+    Your response MUST be a valid Python dictionary in the format: {{key1: value1, key2: value2, ...}}
     Format your entire response as a valid Python dictionary ONLY with no other text.
     """
     df[prompt_column] = prefix + df[serialized_input_column] + suffix
@@ -90,8 +90,8 @@ def parse_llm_output(llm_output: Union[str, Exception], no_cols:int) -> Union[Di
     try:
         match = re.search(r"{.*}",llm_output,re.DOTALL)
         dict_str = match.group()
-        dict_output = ast.literal_eval(dict_str)
-        ret = dict(list(dict_output.items())[no_cols:])
+        ret = ast.literal_eval(dict_str)
+       # ret = dict(list(dict_output.items()))
         if not isinstance(ret, dict):
             raise ValueError(f"Expected a dictionary, got {type(ret)}")
         return ret

--- a/datatune/llm/batch_utils.py
+++ b/datatune/llm/batch_utils.py
@@ -9,7 +9,8 @@ def create_batched_prompts(input_rows: List[str], batch_prefix: str, prompt_per_
     token count for each batch does not exceed the maximum token limit for the given model.
 
     Args:
-        prompts (List[str]): List of prompts.
+        input_rows (List[str]): List of input prompts.
+        
         model_name (str): Name of model being used.
 
     Returns:

--- a/datatune/llm/batch_utils.py
+++ b/datatune/llm/batch_utils.py
@@ -1,7 +1,7 @@
 from litellm import token_counter, get_max_tokens
 from typing import List
 
-def create_batched_prompts(prompts: List[str], model_name: str, prefix:str):
+def create_batched_prompts(prompts: List[str], model_name: str) -> List[str]:
     """
     Groups a list of prompts into batches for LLM.
 
@@ -11,37 +11,47 @@ def create_batched_prompts(prompts: List[str], model_name: str, prefix:str):
     Args:
         prompts (List[str]): List of prompts.
         model_name (str): Name of model being used.
-        prefix (str): Context for each batch.
 
     Returns:
         List[str]: A list of prompt batches, each within the token limit of the model.
 
     """
+    prefix = (
+        "You will be given multiple requests. Each request will:\n"
+        "- End with '<endofquestion>'\n\n"
+        "You MUST respond to each request in order. For each answer:\n"
+        "- End with '<endofresponse>'\n"
+        "- Do NOT skip or omit any requests\n"
+        "Your entire response MUST include one answer per request. Respond strictly in the format described.\n\n"
+        "Questions:\n"
+    )
+
     model_name = model_name[model_name.index("/")+1:] 
     max_tokens = get_max_tokens(model_name)
-    batch_str = ""
-    batch_list = []
-    api_calls = []
+
+    message = [{"role": "user", "content": prefix}]
+    batched_prompts = []
+    nrows_per_api_call = []
     count = 0
     for prompt in prompts:
-        message =[{"role": "user", "content": f"{prefix}{batch_str}Q-{count}: {prompt} <endofquestion>\n"}]                 
-        total_tokens = token_counter(model_name, messages=message)
-        if total_tokens < max_tokens:
-            count +=1
-            batch_str += f"Q-{count}: {prompt} <endofquestion>\n"
+        q = f"{prompt} <endofquestion>\n"
+        message[0]["content"] += q
+        ntokens = token_counter(model_name, messages=message)
+        if ntokens < max_tokens:
+            count += 1
         else:
-            batch_list.append(batch_str)
-            api_calls.append(count)
-            
-             
-            count = 1
-            batch_str =f"Q-{count}: {prompt} <endofquestion>\n"
-    
-    if batch_str:
-        batch_list.append(batch_str)
-        api_calls.append(count)
+            message[0]["content"] = message[0]["content"][:-len(q)]
+            batched_prompts.append(message[0]["content"])
+            nrows_per_api_call.append(count)
 
-    print(api_calls)
-    print("No of rows: ",sum(api_calls))
-    print("No of api calls: ",len(api_calls))
-    return batch_list
+            count = 1
+            message[0]["content"] = f"{prefix}{prompt} <endofquestion>\n"
+    
+    if count > 0:
+        batched_prompts.append(message[0]["content"])
+        nrows_per_api_call.append(count)
+
+    print(nrows_per_api_call)
+    print("No of rows:", sum(nrows_per_api_call))
+    print("No of api calls:", len(nrows_per_api_call))
+    return batched_prompts

--- a/datatune/llm/batch_utils.py
+++ b/datatune/llm/batch_utils.py
@@ -1,34 +1,59 @@
 from litellm import token_counter, get_max_tokens
 from typing import List
 def token_count_string(messages:str, model_name:str):
+    """
+    Counts the number of tokens in a given string prompt when formatted as chat completion message.
+
+    Args:
+        messages (str): The input prompt string.
+        model_name (str): Name of the model used.
+
+    Returns:
+        int: The total number of tokens used by the formatted chat message.
+    """
     messages=[{"role": "user", "content": messages}]
     return token_counter(model_name, messages=messages)
 
 def create_batch_list(prompts: List[str], model_name: str, prefix:str):
+    """
+    Groups a list of prompts into batches for LLM.
+
+    This function concatenates prompts into batch strings, ensuring that the total
+    token count for each batch does not exceed the maximum token limit for the given model.
+
+    Args:
+        prompts (List[str]): List of prompts.
+        model_name (str): Name of model being used.
+        prefix (str): Context for each batch.
+
+    Returns:
+        List[str]: A list of prompt batches, each within the token limit of the model.
+
+    """
     model_name = model_name[model_name.index("/")+1:] 
     max_tokens = get_max_tokens(model_name)
     batch_str = ""
     batch_list = []
-    count = []
-    counts = 0
+    api_calls = []
+    count = 0
     for i in prompts:
         if token_count_string(prefix+batch_str + f"{i} <endofquestion>\n",model_name) < max_tokens:
-            counts +=1
+            count +=1
             batch_str += f"{i} <endofquestion>\n"
         else:
             batch_list.append(batch_str)
-            count.append(counts)
+            api_calls.append(count)
             
              
-            counts = 1
+            count = 1
             batch_str =f"{i} <endofquestion>\n"
     
     if batch_str:
         batch_list.append(batch_str)
-        count.append(counts)
+        api_calls.append(count)
 
-    print(count)
-    print("sum: ",sum(count))
+    print(api_calls)
+    print("sum: ",sum(api_calls))
     return batch_list
 
 

--- a/datatune/llm/batch_utils.py
+++ b/datatune/llm/batch_utils.py
@@ -1,18 +1,5 @@
 from litellm import token_counter, get_max_tokens
 from typing import List
-'''def token_count_string(messages:str, model_name:str):
-    """
-    Counts the number of tokens in a given string prompt when formatted as chat completion message.
-
-    Args:
-        messages (str): The input prompt string.
-        model_name (str): Name of the model used.
-
-    Returns:
-        int: The total number of tokens used by the formatted chat message.
-    """
-    messages=[{"role": "user", "content": messages}]
-    return token_counter(model_name, messages=messages)'''
 
 def create_batched_prompts(prompts: List[str], model_name: str, prefix:str):
     """

--- a/datatune/llm/batch_utils.py
+++ b/datatune/llm/batch_utils.py
@@ -1,6 +1,6 @@
 from litellm import token_counter, get_max_tokens
 from typing import List
-def token_count_string(messages:str, model_name:str):
+'''def token_count_string(messages:str, model_name:str):
     """
     Counts the number of tokens in a given string prompt when formatted as chat completion message.
 
@@ -12,9 +12,9 @@ def token_count_string(messages:str, model_name:str):
         int: The total number of tokens used by the formatted chat message.
     """
     messages=[{"role": "user", "content": messages}]
-    return token_counter(model_name, messages=messages)
+    return token_counter(model_name, messages=messages)'''
 
-def create_batch_list(prompts: List[str], model_name: str, prefix:str):
+def create_batched_prompts(prompts: List[str], model_name: str, prefix:str):
     """
     Groups a list of prompts into batches for LLM.
 
@@ -36,17 +36,19 @@ def create_batch_list(prompts: List[str], model_name: str, prefix:str):
     batch_list = []
     api_calls = []
     count = 0
-    for i in prompts:
-        if token_count_string(prefix+batch_str + f"Q-{count}: {i} <endofquestion>\n",model_name) < max_tokens:
+    for prompt in prompts:
+        message =[{"role": "user", "content": f"{prefix}{batch_str}Q-{count}: {prompt} <endofquestion>\n"}]                 
+        total_tokens = token_counter(model_name, messages=message)
+        if total_tokens < max_tokens:
             count +=1
-            batch_str += f"Q-{count}: {i} <endofquestion>\n"
+            batch_str += f"Q-{count}: {prompt} <endofquestion>\n"
         else:
             batch_list.append(batch_str)
             api_calls.append(count)
             
              
             count = 1
-            batch_str =f"Q-{count}: {i} <endofquestion>\n"
+            batch_str =f"Q-{count}: {prompt} <endofquestion>\n"
     
     if batch_str:
         batch_list.append(batch_str)

--- a/datatune/llm/batch_utils.py
+++ b/datatune/llm/batch_utils.py
@@ -53,7 +53,6 @@ def create_batch_list(prompts: List[str], model_name: str, prefix:str):
         api_calls.append(count)
 
     print(api_calls)
-    print("sum: ",sum(api_calls))
+    print("No of rows: ",sum(api_calls))
+    print("No of api calls: ",len(api_calls))
     return batch_list
-
-

--- a/datatune/llm/batch_utils.py
+++ b/datatune/llm/batch_utils.py
@@ -37,16 +37,16 @@ def create_batch_list(prompts: List[str], model_name: str, prefix:str):
     api_calls = []
     count = 0
     for i in prompts:
-        if token_count_string(prefix+batch_str + f"{i} <endofquestion>\n",model_name) < max_tokens:
+        if token_count_string(prefix+batch_str + f"Q-{count}: {i} <endofquestion>\n",model_name) < max_tokens:
             count +=1
-            batch_str += f"{i} <endofquestion>\n"
+            batch_str += f"Q-{count}: {i} <endofquestion>\n"
         else:
             batch_list.append(batch_str)
             api_calls.append(count)
             
              
             count = 1
-            batch_str =f"{i} <endofquestion>\n"
+            batch_str =f"Q-{count}: {i} <endofquestion>\n"
     
     if batch_str:
         batch_list.append(batch_str)

--- a/datatune/llm/batch_utils.py
+++ b/datatune/llm/batch_utils.py
@@ -1,0 +1,34 @@
+from litellm import token_counter, get_max_tokens
+from typing import List
+def token_count_string(messages:str, model_name:str):
+    messages=[{"role": "user", "content": messages}]
+    return token_counter(model_name, messages=messages)
+
+def create_batch_list(prompts: List[str], model_name: str, prefix:str):
+    model_name = model_name[model_name.index("/")+1:] 
+    max_tokens = get_max_tokens(model_name)
+    batch_str = ""
+    batch_list = []
+    count = []
+    counts = 0
+    for i in prompts:
+        if token_count_string(prefix+batch_str + f"{i} <endofquestion>\n",model_name) < max_tokens:
+            counts +=1
+            batch_str += f"{i} <endofquestion>\n"
+        else:
+            batch_list.append(batch_str)
+            count.append(counts)
+            
+             
+            counts = 1
+            batch_str =f"{i} <endofquestion>\n"
+    
+    if batch_str:
+        batch_list.append(batch_str)
+        count.append(counts)
+
+    print(count)
+    print("sum: ",sum(count))
+    return batch_list
+
+

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -70,14 +70,22 @@ class LLM:
     def __call__(self, prompt: Union[str, List[str]]) -> List[str]:
         """Always return a list of strings, regardless of input type"""
 
-        self.prefix =("You will be given multiple questions starting with the question number and ending with <endofquestion>.\n"
-                      "Separate each answer with <endofresponse>.\n"
-                      "Do not leave any answers blank\n\n"
-                       f"Questions:\n")
+        self.prefix =(
+            "You will be given multiple questions. Each question will:\n"
+            "- Start with 'Q-[number]:'\n"
+            "- End with '<endofquestion>'\n\n"
+            "You MUST respond to each question in order. For each answer:\n"
+            "- End with '<endofresponse>'\n"
+            "- Do NOT skip or omit any question\n"
+            "- Do NOT leave any answer blank\n\n"
+            "- Always respond with the entire input data record with the added key value pairs as per the questions"
+            "Your entire response MUST include one answer per question. Respond strictly in the format described.\n\n"
+            "Questions:\n"
+        )
         
         if isinstance(prompt, str):
             return [self._completion(prompt)]
-        return self._batch_completion(create_batch_list(prompt, self.model_name, self.prefix))
+        return self._true_batch_completion(create_batch_list(prompt, self.model_name, self.prefix))
 
 
 class Ollama(LLM):

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -75,6 +75,7 @@ class LLM:
             "- Start with 'Q-[number]:'\n"
             "- End with '<endofquestion>'\n\n"
             "You MUST respond to each question in order. For each answer:\n"
+            "- Start with answer number(e.g - A1,A2...)"
             "- End with '<endofresponse>'\n"
             "- Do NOT skip or omit any question\n"
             "- Do NOT leave any answer blank\n\n"

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -75,11 +75,8 @@ class LLM:
             "- Start with 'Q-[number]:'\n"
             "- End with '<endofquestion>'\n\n"
             "You MUST respond to each question in order. For each answer:\n"
-            "- Start with answer number(e.g - A1,A2...)"
             "- End with '<endofresponse>'\n"
             "- Do NOT skip or omit any question\n"
-            "- Do NOT leave any answer blank\n\n"
-            "- Always respond with the entire input data record with the added key value pairs as per the questions"
             "Your entire response MUST include one answer per question. Respond strictly in the format described.\n\n"
             "Questions:\n"
         )

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -77,7 +77,7 @@ class LLM:
         
         if isinstance(prompt, str):
             return [self._completion(prompt)]
-        return self._true_batch_completion(create_batch_list(prompt, self.model_name, self.prefix))
+        return self._batch_completion(create_batch_list(prompt, self.model_name, self.prefix))
 
 
 class Ollama(LLM):


### PR DESCRIPTION
## Summary

- `create_batched_prompts` function takes a list of prompts and groups them into batches based on the token limit of the given model
- This list of "batched prompts" are passed into `_true_batch_completion` function.
- `_true_batch_completion` function:
    - Minimizes API calls as input for each call contains the maximum number of tokens allowed.
    - Parses LLM output and returns a list of responses.
    - Ensures that the **token-per-minute** and **requests-per-minute** limits are not exceeded
    - Retries failed or malformed requests.
    - Ensure number of responses are consistent with the number of requests.
  

## Relevant Issues
- Fixes #46 
- Fixes #45 
- Fixes #49 



