### PR TITLE
Dynamic rpm and tpm

### DIFF
--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -40,13 +40,13 @@ def filter_prompt(
     """
     filtering_context = (
         f"You are filtering a dataset. Your task is to determine whether each data record should be KEPT or REMOVED based on the filtering criteria below.{os.linesep}"
-        f"Return the entire input data record with an added key called 'filter' with value either True to KEEP the record or False to REMOVE it.{os.linesep}{os.linesep}"
+        f"Return the entire input data record with an added key called '__filter__' with value either True to KEEP the record or False to REMOVE it.{os.linesep}{os.linesep}"
         f"FILTERING CRITERIA:{os.linesep}{prompt}{os.linesep}{os.linesep}"
         f"DATA RECORD TO EVALUATE:{os.linesep}"
     )
     instructions = (
         f"{os.linesep}{os.linesep}"
-        f"DECISION:Your response MUST be a valid Python dictionary in the format: {{key1: value1, key2: value2, ...}} with added key called 'filter' with value either True to KEEP the record or False to REMOVE it."
+        f"DECISION:Your response MUST be a valid Python dictionary in the format: {{key1: value1, key2: value2, ...}} with added key called '__filter__' with value either True to KEEP the record or False to REMOVE it."
         f"No explanations or additional text."
     )
     df[prompt_column] = filtering_context + df[serialized_input_column] + instructions
@@ -70,12 +70,12 @@ def llm_batch_inference(llm: Callable, llm_output_column: str, prompt: str, seri
     """
     prefix = (
         f"You are filtering a dataset. Your task is to determine whether each data record should be KEPT or REMOVED based on the filtering criteria below.{os.linesep}"
-        f"Return the entire input data record with an added key called 'filter' with value either True to KEEP the record or False to REMOVE it.{os.linesep}{os.linesep}"
+        f"Return the entire input data record with an added key called '__filter__' with value either True to KEEP the record or False to REMOVE it.{os.linesep}{os.linesep}"
     )
     prompt = f"FILTERING CRITERIA:{os.linesep}{prompt}{os.linesep}{os.linesep}"
     suffix = (
         f"{os.linesep}{os.linesep}"
-        f"DECISION:Your response MUST be a valid Python dictionary in the format: {{key1: value1, key2: value2, ...}} with added key called 'filter' with value either True to KEEP the record or False to REMOVE it."
+        f"DECISION:Your response MUST be a valid Python dictionary in the format: {{key1: value1, key2: value2, ...}} with added key called '__filter__' with value either True to KEEP the record or False to REMOVE it."
         f"No explanations or additional text."
     )
     df[llm_output_column] = llm(df[serialized_input_column], prefix, prompt, suffix)
@@ -120,10 +120,10 @@ def parse_filter_output(output: Union[str, Exception], err: bool = True) -> Opti
         logging.error(f"LLM error: {output}")
         return None
     
-    match = re.search(r"{.*}",output,re.DOTALL)
-    dict_str = match.group()
-    output_dict = ast.literal_eval(dict_str)
-    output = output_dict.get("filter", None)
+   # match = re.search(r"{.*}",output,re.DOTALL)
+   # dict_str = match.group()
+    output_dict = ast.literal_eval(output[output.index("{"):output.index("}")+1])
+    output = output_dict.get("__filter__", None)
     
     if isinstance(output, bool):
         return output

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -120,9 +120,9 @@ def parse_llm_output(llm_output: Union[str, Exception]) -> Union[Dict, Exception
         logging.error(f"LLM Error: {llm_output}")
         return llm_output
     try:
-        match = re.search(r"{.*}",llm_output,re.DOTALL)
-        dict_str = match.group()
-        ret = ast.literal_eval(dict_str)
+      #  match = re.search(r"{.*}",llm_output,re.DOTALL)
+      #  dict_str = match.group()
+        ret = ast.literal_eval(llm_output[llm_output.index("{"):llm_output.index("}")+1])
         
         if not isinstance(ret, dict):
             raise ValueError(f"Expected a dictionary, got {type(ret)}")
@@ -289,7 +289,7 @@ class BatchedMap(Map):
         The mapping process involves:
         1. Serializing each row to string format
         2. Creating prompts for the LLM
-        3. Running LLM inference on the prompts
+        3. Running LLM inference on the serialized input rows
         4. Parsing the results and updating the DataFrame with transformed values
 
         Args:

--- a/datatune/llm/batch_utils.py
+++ b/datatune/llm/batch_utils.py
@@ -57,3 +57,123 @@ def create_batched_prompts(input_rows: List[str], batch_prefix: str, prompt_per_
     print("No of rows:", sum(nrows_per_api_call))
     print("No of api calls:", len(nrows_per_api_call))
     return batched_prompts
+
+def get_model_limits(model_name:str):
+    model_rate_limits = {
+        "gpt-3.5-turbo": {
+            "tpm": 200_000,
+            "rpm": 500,
+        },
+        "gpt-3.5-turbo-0125": {
+            "tpm": 200_000,
+            "rpm": 500,
+        },
+        "gpt-3.5-turbo-1106": {
+            "tpm": 200_000,
+            "rpm": 500,
+        },
+        "gpt-3.5-turbo-16k": {
+            "tpm": 200_000,
+            "rpm": 500,
+        },
+        "gpt-3.5-turbo-instruct": {
+            "tpm": 90_000,
+            "rpm": 3500,
+        },
+        "gpt-3.5-turbo-instruct-0914": {
+            "tpm": 90_000,
+            "rpm": 3500,
+        },
+        "gpt-4": {
+            "tpm": 10_000,
+            "rpm": 500,
+        },
+        "gpt-4-0613": {
+            "tpm": 10_000,
+            "rpm": 500,
+        },
+        "gpt-4-turbo": {
+            "tpm": 30_000,
+            "rpm": 500,
+        },
+        "gpt-4-turbo-2024-04-09": {
+            "tpm": 30_000,
+            "rpm": 500,
+        },
+        "gpt-4-turbo-preview": {
+            "tpm": 30_000,
+            "rpm": 500,
+        },
+        "gpt-4-0125-preview": {
+            "tpm": 30_000,
+            "rpm": 500,
+        },
+        "gpt-4-1106-preview": {
+            "tpm": 30_000,
+            "rpm": 500,
+        },
+        "gpt-4.1": {
+            "tpm": 30_000,
+            "rpm": 500,
+        },
+        "gpt-4.1-2025-04-14": {
+            "tpm": 30_000,
+            "rpm": 500,
+        },
+        "gpt-4.1-mini": {
+            "tpm": 200_000,
+            "rpm": 500,
+        },
+        "gpt-4.1-mini-2025-04-14": {
+            "tpm": 200_000,
+            "rpm": 500,
+        },
+        "gpt-4.1-nano": {
+            "tpm": 200_000,
+            "rpm": 500,
+        },
+        "gpt-4.1-nano-2025-04-14": {
+            "tpm": 200_000,
+            "rpm": 500,
+        },
+        "gpt-4.5-preview": {
+            "tpm": 125_000,
+            "rpm": 1000,
+        },
+        "gpt-4.5-preview-2025-02-27": {
+            "tpm": 125_000,
+            "rpm": 1000,
+        },
+        "gpt-4o": {
+            "tpm": 30_000,
+            "rpm": 500,
+        },
+        "gpt-4o-2024-05-13": {
+            "tpm": 30_000,
+            "rpm": 500,
+        },
+        "gpt-4o-2024-08-06": {
+            "tpm": 30_000,
+            "rpm": 500,
+        },
+        "gpt-4o-2024-11-20": {
+            "tpm": 30_000,
+            "rpm": 500,
+        },
+    }
+    model_name = model_name[model_name.index("/")+1:] 
+    if model_name in model_rate_limits:
+        return model_rate_limits[model_name]
+    return model_rate_limits["gpt-3.5-turbo"]
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
## Changes
- `MAX_RPM` and `MAX_TPM` are no longer hardcoded and can be set by users using environment variables.

     `os.environ["MAX_TPM"] = "200000"`
     `os.environ["MAX_RPM"] = "6"`

- If the environment variables `MAX_RPM` and `MAX_TPM` are not set, the rate limits will fall back to values based on the model name using a lookup dictionary defined in  **batch_utils.py**
- If model name does not exist in the lookup dictionary  `MAX_RPM` and `MAX_TPM` defaults to **gpt-3.5-turbo** rate limits.

## Drawbacks
- Right now the lookup dictionary contains only OpenAI models with OpenAI API rate limits.