### PR TITLE
Reduce tokens by sending relevant rows only

### DIFF
--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -21,7 +21,7 @@ def input_as_string(serialized_input_column: str, df: pd.DataFrame, input_fields
         pd.DataFrame: DataFrame with the added serialized input column.
     """
     
-    df_inputs = df[input_fields]
+    df_inputs = df[input_fields] if input_fields else df
     df[serialized_input_column] = [str(row.to_dict()) for _, row in df_inputs.iterrows()]
     return df
 

--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -20,10 +20,9 @@ def input_as_string(serialized_input_column: str, df: pd.DataFrame, input_fields
     Returns:
         pd.DataFrame: DataFrame with the added serialized input column.
     """
-    if input_fields:
-        df[serialized_input_column] = [str({k:v for k,v in row.to_dict().items() if k in input_fields}) for _, row in df.iterrows()]
-    else:
-        df[serialized_input_column] = [str(row.to_dict()) for _, row in df.iterrows()]
+    
+    df_inputs = df[input_fields]
+    df[serialized_input_column] = [str(row.to_dict()) for _, row in df_inputs.iterrows()]
     return df
 
 def llm_batch_inference(

--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -8,18 +8,22 @@ import logging
 import ast
 
 
-def input_as_string(serialized_input_column: str, df: pd.DataFrame) -> pd.DataFrame:
+def input_as_string(serialized_input_column: str, df: pd.DataFrame, input_fields:Optional[List[str]] = None) -> pd.DataFrame:
     """
     Converts each row in the DataFrame to a string representation and stores it in a new column.
 
     Args:
         serialized_input_column (str): Name of the column to store the serialized row data.
         df (pd.DataFrame): Input DataFrame to process.
+        input_fields (Optional[List], optional): List of input fields to include. Defaults to None.
 
     Returns:
         pd.DataFrame: DataFrame with the added serialized input column.
     """
-    df[serialized_input_column] = [str(row.to_dict()) for _, row in df.iterrows()]
+    if input_fields:
+        df[serialized_input_column] = [str({k:v for k,v in row.to_dict().items() if k in input_fields}) for _, row in df.iterrows()]
+    else:
+        df[serialized_input_column] = [str(row.to_dict()) for _, row in df.iterrows()]
     return df
 
 def llm_batch_inference(
@@ -207,7 +211,7 @@ class Filter(Op):
         if drop_columns:
             df = df.drop(columns=drop_columns)
 
-        df = df.map_partitions(partial(input_as_string, self.serialized_input_column))
+        df = df.map_partitions(partial(input_as_string, self.serialized_input_column, input_fields=self.input_fields))
         meta_dict = df._meta.dtypes.to_dict()
         meta_dict[self.llm_output_column] = str
         llm_outputs = df.map_partitions(

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -21,7 +21,7 @@ def input_as_string(serialized_input_column: str, df: pd.DataFrame, input_fields
     Returns:
         pd.DataFrame: DataFrame with the added serialized input column.
     """
-    df_inputs = df[input_fields]
+    df_inputs = df[input_fields] if input_fields else df
     df[serialized_input_column] = [str(row.to_dict()) for _, row in df_inputs.iterrows()]
     return df
 

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -21,10 +21,8 @@ def input_as_string(serialized_input_column: str, df: pd.DataFrame, input_fields
     Returns:
         pd.DataFrame: DataFrame with the added serialized input column.
     """
-    if input_fields:
-        df[serialized_input_column] = [str({k:v for k,v in row.to_dict().items() if k in input_fields}) for _, row in df.iterrows()]
-    else:
-        df[serialized_input_column] = [str(row.to_dict()) for _, row in df.iterrows()]
+    df_inputs = df[input_fields]
+    df[serialized_input_column] = [str(row.to_dict()) for _, row in df_inputs.iterrows()]
     return df
 
 

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -9,19 +9,24 @@ from datatune.core.constants import DELETED_COLUMN, ERRORED_COLUMN
 import logging
 
 
-def input_as_string(serialized_input_column: str, df: pd.DataFrame) -> pd.DataFrame:
+def input_as_string(serialized_input_column: str, df: pd.DataFrame, input_fields:Optional[List[str]] = None) -> pd.DataFrame:
     """
     Converts each row in the DataFrame to a string representation and stores it in a new column.
 
     Args:
         serialized_input_column (str): Name of the column to store the serialized row data.
         df (pd.DataFrame): Input DataFrame to process.
+        input_fields (Optional[List], optional): List of input fields to include. Defaults to None.
 
     Returns:
         pd.DataFrame: DataFrame with the added serialized input column.
     """
-    df[serialized_input_column] = [str(row.to_dict()) for _, row in df.iterrows()]
+    if input_fields:
+        df[serialized_input_column] = [str({k:v for k,v in row.to_dict().items() if k in input_fields}) for _, row in df.iterrows()]
+    else:
+        df[serialized_input_column] = [str(row.to_dict()) for _, row in df.iterrows()]
     return df
+
 
 def llm_batch_inference(
     llm: Callable,
@@ -199,7 +204,7 @@ class Map(Op):
         Returns:
             Dict: The processed DataFrame with transformed values.
         """
-        df = df.map_partitions(partial(input_as_string, self.serialized_input_column))
+        df = df.map_partitions(partial(input_as_string, self.serialized_input_column, input_fields=self.input_fields))
 
         meta_dict = df._meta.dtypes.to_dict()
         meta_dict[self.llm_output_column] = str

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -110,6 +110,7 @@ class LLM:
             """
             from litellm import batch_completion
 
+            print("Number of batches sent: ",len(messages))
             responses = batch_completion(
                 model=self.model_name, messages=messages, **self.kwargs
             )


### PR DESCRIPTION
## Changes
- Users can now pass an argument called `input fields` to `Map` and `Filter`
```python
# Transform data with Map
mapped = dt.Map(    
    prompt="Extract price condition from price columun (yes if more than 300 dollars)",
    output_fields=["Expensive"],
    input_fields=["Price"]
   
)(llm, df)
# Filter data based on criteria
filtered = dt.Filter(
    prompt="Keep only products that are in stock",
    input_fields=["Availability"] 
    
)(llm, mapped)
```
Here only **Price**  and **Availability** column will be sent as input rows to the LLM API

- Sending only relevant columns reduces the total number of tokens and hence the total cost is reduced