### PR TITLE
Get input fields using LLM

### DIFF
--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -7,7 +7,6 @@ from datatune.core.constants import DELETED_COLUMN, ERRORED_COLUMN
 import logging
 import ast
 
-
 def input_as_string(serialized_input_column: str, df: pd.DataFrame, input_fields:Optional[List[str]] = None) -> pd.DataFrame:
     """
     Converts each row in the DataFrame to a string representation and stores it in a new column.
@@ -209,6 +208,10 @@ class Filter(Op):
 
         if drop_columns:
             df = df.drop(columns=drop_columns)
+        
+        if not self.input_fields:
+            first_row_dict = df.head(1).iloc[0].to_dict()
+            self.input_fields = llm.get_input_fields(first_row_dict, self.prompt)
 
         df = df.map_partitions(partial(input_as_string, self.serialized_input_column, input_fields=self.input_fields))
         meta_dict = df._meta.dtypes.to_dict()

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -21,6 +21,7 @@ def input_as_string(serialized_input_column: str, df: pd.DataFrame, input_fields
     Returns:
         pd.DataFrame: DataFrame with the added serialized input column.
     """
+    #print(input_fields)
     df_inputs = df[input_fields] if input_fields else df
     df[serialized_input_column] = [str(row.to_dict()) for _, row in df_inputs.iterrows()]
     return df
@@ -202,6 +203,10 @@ class Map(Op):
         Returns:
             Dict: The processed DataFrame with transformed values.
         """
+        if not self.input_fields:
+            first_row = df.head(1).iloc[0].to_dict()
+            self.input_fields = llm.get_input_fields(first_row, self.prompt)
+
         df = df.map_partitions(partial(input_as_string, self.serialized_input_column, input_fields=self.input_fields))
 
         meta_dict = df._meta.dtypes.to_dict()

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -77,7 +77,6 @@ class LLM:
                     model=self.model_name, messages=message, **self.kwargs
                 )
         response_str = response["choices"][0]["message"]["content"]
-        print("this is response_Str ",response_str)
         input_fields = ast.literal_eval(response_str[response_str.index('['):response_str.index(']')+1])
         return input_fields
 


### PR DESCRIPTION
## Changes
- New `LLM` method called `get_input_fields`.
- `get_input_fields` uses sends the first row and the `Filter` or `Map` prompt to the given LLM's api using `litellm.completion()`.
- The LLM is given a prompt to return a list of column names relevant to the `Map` or `Filter` prompt.
- `get_input_fields` is only called only if the `input_fields` argument is not passed by the user to `Map` or `Filter`.

## Drawbacks
- Prompt needs workshopping
- `first_row_dict = df.head(1).iloc[0].to_dict()` is used to get the first row. Getting the first row involves computing the dask dataframe and pulling it into memory. The entire Map-Filter-finalize pipeline executes when we call `compute().to_csv()` on the result (dask dataframe) returned from `finalize` so computing the dask dataframe within `Filter` causes `Map` to run twice.
