### PR TITLE
Top level api exposure for Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,13 @@ llm = OpenAI(model_name="gpt-3.5-turbo")
 Datatune provides an agentic framework which allows you to deploy agents that can generate and execute python scripts with datatune operations.
 
 ```python
-from datatune.agent.agent import Agent
+import datatue as dt
 from datatune.llm.llm import OpenAI
 
 llm = OpenAI(model_name="gpt-3.5-turbo",tpm=200000)
 
 # Initialize an agent by providing an LLM
-agent = Agent(llm)
+agent = dt.Agent(llm)
 prompt = "your prompt for data transformation"
 
 # Transform your dask DataFrame

--- a/datatune/__init__.py
+++ b/datatune/__init__.py
@@ -1,5 +1,5 @@
 from datatune.core.map import Map
 from datatune.core.filter import Filter
 from datatune.core.op import finalize
-
-__all__ = ["Map", "Filter", "finalize"]
+from datatune.agent.agent import Agent
+__all__ = ["Map", "Filter", "finalize","Agent"]


### PR DESCRIPTION
## Changes
- Agent() now works as `dt.Agent()`
- Updated readme
```python
import datatue as dt
from datatune.llm.llm import OpenAI

llm = OpenAI(model_name="gpt-3.5-turbo",tpm=200000)
agent = dt.Agent(llm)
prompt = "your prompt for data transformation"
df = agent.do(prompt,df)