### PR TITLE
Step execution

### DIFF
--- a/datatune/agent/agent.py
+++ b/datatune/agent/agent.py
@@ -35,7 +35,7 @@ class Agent(ABC):
     "primitive": {
 
         "Map": textwrap.dedent("""\
-            mapped = Map(
+            mapped = dt.Map(
                 prompt="{subprompt}",
                 input_fields={input_fields},
                 output_fields={output_fields}
@@ -43,7 +43,7 @@ class Agent(ABC):
             df = mapped
         """),
         "Filter": textwrap.dedent("""\
-            filtered = Filter(
+            filtered = dt.Filter(
                 prompt="{subprompt}",
                 input_fields={input_fields}
             )(llm, df)
@@ -127,8 +127,9 @@ class Agent(ABC):
         INSTRUCTIONS: 1.ONLY USE OPERATIONS AND PARAM NAMES FROM THE TEMPLATE GIVEN BELOW
         {TEMPLATE}
 
-        2. When generating a plan, always prefer using Dask operations for any data transformation that can be expressed programmatically (e.g., filtering, grouping, aggregating, adding columns, renaming, merging, sorting).
-           Only use primitive operations (such as Map, Filter, Finalize) when the task requires contextual understanding of the data's meaning that cannot be achieved through Dask alone (e.g., semantic extraction, classification, interpretation, natural language reasoning).
+        2. Use existing dask functions in expressions
+        3. When generating a plan, always prefer using Dask operations for any data transformation that can be expressed programmatically (e.g., filtering, grouping, aggregating, adding columns, renaming, merging, sorting).
+           Only use primitive operations (such as Map, Filter) when the task requires contextual understanding of the data's meaning that cannot be achieved through Dask alone (e.g., semantic extraction, classification, interpretation, natural language reasoning).
 
         Generate the JSON plan for the following TASK:
 
@@ -211,7 +212,7 @@ class Agent(ABC):
         runtime["df"] = df
         runtime["llm"] = self.llm
         runtime.execute(
-            "import numpy as np\nimport pandas as pd\nimport dask.dataframe as dd\nfrom datatune.datatune.core.map import Map\nfrom datatune.datatune.core.filter import Filter\n"
+            "import numpy as np\nimport pandas as pd\nimport dask.dataframe as dd\nimport datatune as dt\n"
         )
 
     def do(self, task: str, df: dd.DataFrame, max_iterations: int = 5) -> dd.DataFrame:

--- a/datatune/agent/agent.py
+++ b/datatune/agent/agent.py
@@ -73,39 +73,39 @@ class Agent(ABC):
 
         EXAMPLE OUTPUT:
         [
-        {
+        {{
             "type": "primitive",
             "operation": "Map",
-            "params": {
+            "params": {{
                 "subprompt": "Extract category and sub-category from industry",
                 "input_fields": ["Industry"],
                 "output_fields": ["Category","Sub-Category"]
-            }
-        },
-        {
+            }},
+        }},
+        {{
             "type": "primitive",
             "operation": "Filter",
-            "params": {
+            "params": {{
                 "subprompt": "Keep only organizations in Africa",
                 "input_fields": ["Country"]
-            }
-        },
-        {
+            }},
+        }},
+        {{
             "type": "dask",
             "operation": "add_column",
-            "params": {
+            "params": {{
             "new_column": "Year",
             "expression": "df['Date'].dt.year"
-            }
-        },
-        {
+            }}
+        }},
+        {{
             "type": "dask",
             "operation": "group_by_agg",
-            "params": {
+            "params": {{
             "group_columns": ["Year", "Month"],
-            "aggregations": "{'Gross Amount':'sum'}"
-            }
-        }
+            "aggregations": {{'Gross Amount':'sum'}}
+            }}
+        }}
         ]
 
         Generate the JSON plan for the following TASK:
@@ -228,8 +228,6 @@ class Agent(ABC):
         
         iteration = 0
         done = False
-        last_error = None
-        last_failed_code = None
         error_msg = ""
         prompt = self.get_full_prompt(
             df, 
@@ -244,5 +242,12 @@ class Agent(ABC):
                 error_msg = self._execute_step(step)
                 if error_msg:
                     error_msg = self.get_error_prompt(error_msg, step)
-                    break
-            continue
+                    self.history = []
+                    break  
+                else:
+                    print(f"✅ Executed step: {step}")
+                    self.history.append(step)
+
+            if self.history:
+                continue
+        return self.runtime["df"]

--- a/datatune/agent/agent.py
+++ b/datatune/agent/agent.py
@@ -141,6 +141,7 @@ class Agent(ABC):
             
             # Check if task is done first
             if self.runtime.get("DONE", False):
+                _ = self.runtime["df"].head()
                 return True, None
                 
             # Handle query case
@@ -151,6 +152,7 @@ class Agent(ABC):
                 
                 # Check again if DONE was set to True in the same execution
                 if self.runtime.get("DONE", False):
+                    _ = self.runtime["df"].head() 
                     return True, None
                     
             return False, None

--- a/datatune/agent/agent.py
+++ b/datatune/agent/agent.py
@@ -209,12 +209,10 @@ class Agent(ABC):
         try:
             if step["type"] == "dask":
                 template = self.TEMPLATE["dask"][step["operation"]].format(**step["params"])
-                self.runtime.execute(template)
-                self.runtime.execute("_ = df.head()")
+                self.runtime.execute(template+"\n_ = df.head()")
             elif step["type"] == "primitive":
                 template = self.TEMPLATE["primitive"][step["operation"]].format(**step["params"])
-                self.runtime.execute(template)
-                self.runtime.execute("_ = df.head()")
+                self.runtime.execute(template+"\n_ = df.head()")
             else:
                 raise ValueError(f"Unknown step type: {step['type']}")
             return None
@@ -266,6 +264,7 @@ class Agent(ABC):
             plan = self.get_plan(prompt,error_msg)
             print(f"📝Plan: {plan}")
             for step in plan:
+                print(f"🔍Executing step: {step} {iteration}")
                 error_msg = self._execute_step(step)
                 if error_msg:
                     error_msg = self.get_error_prompt(error_msg, step)

--- a/datatune/agent/agent.py
+++ b/datatune/agent/agent.py
@@ -35,7 +35,7 @@ class Agent(ABC):
     "primitive": {
 
         "Map": textwrap.dedent("""\
-            mapped = Map(
+            mapped = dt.Map(
                 prompt="{subprompt}",
                 input_fields={input_fields},
                 output_fields={output_fields}
@@ -43,7 +43,7 @@ class Agent(ABC):
             df = mapped
         """),
         "Filter": textwrap.dedent("""\
-            filtered = Filter(
+            filtered = dt.Filter(
                 prompt="{subprompt}",
                 input_fields={input_fields}
             )(llm, df)
@@ -233,7 +233,7 @@ class Agent(ABC):
         runtime["QUERY"] = False
         runtime["llm"] = self.llm
         runtime.execute(
-            "import numpy as np\nimport pandas as pd\nimport dask.dataframe as dd\nfrom datatune.datatune.core.map import Map\nfrom datatune.datatune.core.filter import Filter\n"
+            "import numpy as np\nimport pandas as pd\nimport dask.dataframe as dd\nimport datatune as dt\n"
         )
         self.prev_query = None
         self.output_df = None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -12,8 +12,9 @@ def test_agent_dask():
     agent = dt.Agent(llm)
     prompt = "Add a new column called ProfitMargin = (Total Profit / Total Revenue) * 100."
     df = agent.do(prompt,df)
-    result = dt.finalize(df)
     df["ProfitMargin"] = df["ProfitMargin"].astype("float64")
+    result = dt.finalize(df)
+    result.compute().to_csv("agent_dask_results.csv", index=False)
     assert result.columns[-1] == "ProfitMargin"
     assert result["ProfitMargin"].dtype == "float64"
 
@@ -25,13 +26,14 @@ def test_agent_datatune():
     agent = dt.Agent(llm)
     prompt = "Create a new column called Category and Sub-Category based on the Industry column and only keep organizations that are in Africa."
     df = agent.do(prompt,df)
+    df["Category"] = df["Category"].astype("string")
+    df["Sub-Category"] = df["Sub-Category"].astype("string")
     result = dt.finalize(df)
-    #df["Category"] = df["Category"].astype("string")
-    #df["Sub-Category"] = df["Sub-Category"].astype("string")
+    result.compute().to_csv("agent_datatune_results.csv", index=False)
     assert result.columns[-1] == "Sub-Category"
     assert result.columns[-2] == "Category"
-    #assert result["Category"].dtype == "string"
-    #assert result["Sub-Category"].dtype == "string"
+    assert result["Category"].dtype == "string"
+    assert result["Sub-Category"].dtype == "string"
 
 
 def test_agent_combined():
@@ -39,10 +41,11 @@ def test_agent_combined():
     df = dd.read_csv(csv_path)
     llm = OpenAI(model_name="gpt-4o-mini-2024-07-18", tpm=1000000, rpm=5000)
     agent = dt.Agent(llm)
-    prompt = "Create new column called Year for birth year and keep only people who are in STEM related jobs."
+    prompt = "Extract year from date of birth column into a new column called Year and keep only people who are in STEM related jobs."
     df = agent.do(prompt,df)
-    result = dt.finalize(df)
     df["Year"] = df["Year"].astype("int64")
+    result = dt.finalize(df)
+    result.compute().to_csv("agent_combined_results.csv", index=False)
     assert result.columns[-1] == "Year"
-    #assert result["Year"].dtype == "int64"
+    assert result["Year"].dtype == "int64"
     assert len(result) <= len(df)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,48 @@
+import dask.dataframe as dd
+import datatune as dt
+from datatune.llm.llm import OpenAI
+import os
+
+test_path = os.path.dirname(__file__)
+
+def test_agent_dask():
+    csv_path = os.path.join(test_path, "test_data", "dask_only.csv")
+    df = dd.read_csv(csv_path)
+    llm = OpenAI(model_name="gpt-4o-mini-2024-07-18", tpm=1000000, rpm=5000)
+    agent = dt.Agent(llm)
+    prompt = "Add a new column called ProfitMargin = (Total Profit / Total Revenue) * 100."
+    df = agent.do(prompt,df)
+    result = dt.finalize(df)
+    df["ProfitMargin"] = df["ProfitMargin"].astype("float64")
+    assert result.columns[-1] == "ProfitMargin"
+    assert result["ProfitMargin"].dtype == "float64"
+
+
+def test_agent_datatune():
+    csv_path = os.path.join(test_path, "test_data", "datatune_only.csv")
+    df = dd.read_csv(csv_path)
+    llm = OpenAI(model_name="gpt-4o-mini-2024-07-18", tpm=1000000, rpm=5000)
+    agent = dt.Agent(llm)
+    prompt = "Create a new column called Category and Sub-Category based on the Industry column and only keep organizations that are in Africa."
+    df = agent.do(prompt,df)
+    result = dt.finalize(df)
+    #df["Category"] = df["Category"].astype("string")
+    #df["Sub-Category"] = df["Sub-Category"].astype("string")
+    assert result.columns[-1] == "Sub-Category"
+    assert result.columns[-2] == "Category"
+    #assert result["Category"].dtype == "string"
+    #assert result["Sub-Category"].dtype == "string"
+
+
+def test_agent_combined():
+    csv_path = os.path.join(test_path, "test_data", "combined.csv")
+    df = dd.read_csv(csv_path)
+    llm = OpenAI(model_name="gpt-4o-mini-2024-07-18", tpm=1000000, rpm=5000)
+    agent = dt.Agent(llm)
+    prompt = "Create new column called Year for birth year and keep only people who are in STEM related jobs."
+    df = agent.do(prompt,df)
+    result = dt.finalize(df)
+    df["Year"] = df["Year"].astype("int64")
+    assert result.columns[-1] == "Year"
+    #assert result["Year"].dtype == "int64"
+    assert len(result) <= len(df)

--- a/tests/test_data/combined.csv
+++ b/tests/test_data/combined.csv
@@ -1,0 +1,22 @@
+﻿Index,User Id,First Name,Last Name,Sex,Email,Phone,Date of birth,Job Title
+1,88F7B33d2bcf9f5,Shelby,Terrell,Male,elijah57@example.net,001-084-906-7849x73518,10/26/1945,Games developer
+2,f90cD3E76f1A9b9,Phillip,Summers,Female,bethany14@example.com,214.112.6044x4913,3/24/1910,Phytotherapist
+3,DbeAb8CcdfeFC2c,Kristine,Travis,Male,bthompson@example.com,277.609.7938,7/2/1992,Homeopath
+4,A31Bee3c201ef58,Yesenia,Martinez,Male,kaitlinkaiser@example.com,584.094.6111,8/3/2017,Market researcher
+5,1bA7A3dc874da3c,Lori,Todd,Male,buchananmanuel@example.net,689-207-3558x7233,12/1/1938,Veterinary surgeon
+6,bfDD7CDEF5D865B,Erin,Day,Male,tconner@example.org,001-171-649-9856x5553,10/28/2015,Waste management officer
+7,bE9EEf34cB72AF7,Katherine,Buck,Female,conniecowan@example.com,+1-773-151-6685x49162,1/22/1989,Intelligence analyst
+8,2EFC6A4e77FaEaC,Ricardo,Hinton,Male,wyattbishop@example.com,001-447-699-7998x88612,3/26/1924,Hydrogeologist
+9,baDcC4DeefD8dEB,Dave,Farrell,Male,nmccann@example.net,603-428-2429x27392,10/6/2018,Lawyer
+10,8e4FB470FE19bF0,Isaiah,Downs,Male,virginiaterrell@example.org,+1-511-372-1544x8206,9/20/1964,"Engineer, site"
+11,BF0BbA03C29Bb3b,Sheila,Ross,Female,huangcathy@example.com,895.881.4746,3/20/2008,Advertising account executive
+12,F738c69fB34E62E,Stacy,Newton,Male,rayleroy@example.org,710.673.3213x80335,10/20/1980,Warden/ranger
+13,C03fDADdAadAdCe,Mandy,Blake,Male,jefferynoble@example.org,(992)466-1305x4947,12/8/2007,"Scientist, clinical (histocompatibility and immunogenetics)"
+14,b759b74BD1dE80d,Bridget,Nash,Female,mercedes44@example.com,(216)627-8359,6/28/2004,Social worker
+15,1F0B7D65A00DAF9,Crystal,Farmer,Male,pmiranda@example.org,-5791,3/9/1992,Agricultural consultant
+16,50Bb061cB30B461,Thomas,Knight,Female,braunpriscilla@example.net,-2005,2/18/2006,Sport and exercise psychologist
+17,D6dbA5308fEC4BC,Maurice,Rangel,Male,sheenabanks@example.com,(246)187-4969,8/20/2004,Secretary/administrator
+18,311D775990f066d,Frank,Meadows,Male,gbrewer@example.org,429.965.3902x4447,9/16/2008,Audiological scientist
+19,7F7E1BAcb0C9AFf,Alvin,Paul,Male,gilbertdonaldson@example.com,219.436.0887x07551,5/12/1949,"Teacher, adult education"
+20,88473e15D5c3cD0,Jared,Mitchell,Female,jcortez@example.com,-8587,1/18/1921,Paediatric nurse
+21,b31D271F8c200AB,Jacqueline,Norton,Female,carias@example.net,819.309.7679x59173,10/9/1952,"Scientist, marine"

--- a/tests/test_data/dask_only.csv
+++ b/tests/test_data/dask_only.csv
@@ -1,0 +1,15 @@
+﻿Region,Country,Item Type,Sales Channel,Order Priority,Order Date,Order ID,Ship Date,Units Sold,Unit Price,Unit Cost,Total Revenue,Total Cost,Total Profit
+Australia and Oceania,Tuvalu,Baby Food,Offline,H,5/28/2010,669165933,6/27/2010,9925,255.28,159.42,2533654,1582243.5,951410.5
+Central America and the Caribbean,Grenada,Cereal,Online,C,8/22/2012,963881480,9/15/2012,2804,205.7,117.11,576782.8,328376.44,248406.36
+Europe,Russia,Office Supplies,Offline,L,5/2/2014,341417157,5/8/2014,1779,651.21,524.96,1158502.59,933903.84,224598.75
+Sub-Saharan Africa,Sao Tome and Principe,Fruits,Online,C,6/20/2014,514321792,7/5/2014,8102,9.33,6.92,75591.66,56065.84,19525.82
+Sub-Saharan Africa,Rwanda,Office Supplies,Offline,L,2/1/2013,115456712,2/6/2013,5062,651.21,524.96,3296425.02,2657347.52,639077.5
+Australia and Oceania,Solomon Islands,Baby Food,Online,C,2/4/2015,547995746,2/21/2015,2974,255.28,159.42,759202.72,474115.08,285087.64
+Sub-Saharan Africa,Angola,Household,Offline,M,4/23/2011,135425221,4/27/2011,4187,668.27,502.54,2798046.49,2104134.98,693911.51
+Sub-Saharan Africa,Burkina Faso,Vegetables,Online,H,7/17/2012,871543967,7/27/2012,8082,154.06,90.93,1245112.92,734896.26,510216.66
+Sub-Saharan Africa,Republic of the Congo,Personal Care,Offline,M,7/14/2015,770463311,8/25/2015,6070,81.73,56.67,496101.1,343986.9,152114.2
+Sub-Saharan Africa,Senegal,Cereal,Online,H,4/18/2014,616607081,5/30/2014,6593,205.7,117.11,1356180.1,772106.23,584073.87
+Asia,Kyrgyzstan,Vegetables,Online,H,6/24/2011,814711606,7/12/2011,124,154.06,90.93,19103.44,11275.32,7828.12
+Sub-Saharan Africa,Cape Verde,Clothes,Offline,H,8/2/2014,939825713,8/19/2014,4168,109.28,35.84,455479.04,149381.12,306097.92
+Asia,Bangladesh,Clothes,Online,L,1/13/2017,187310731,3/1/2017,8263,109.28,35.84,902980.64,296145.92,606834.72
+Central America and the Caribbean,Honduras,Household,Offline,H,2/8/2017,522840487,2/13/2017,8974,668.27,502.54,5997054.98,4509793.96,1487261.02

--- a/tests/test_data/datatune_only.csv
+++ b/tests/test_data/datatune_only.csv
@@ -1,0 +1,16 @@
+﻿Index,Organization Id,Name,Website,Country,Description,Founded,Industry,Number of employees
+1,E84A904909dF528,Liu-Hoover,http://www.day-hartman.org/,Western Sahara,Ergonomic zero administration knowledge user,1980,Online Publishing,6852
+2,AAC4f9aBF86EAeF,Orr-Armstrong,https://www.chapman.net/,Algeria,Ergonomic radical budgetary management,1970,Import / Export,7994
+3,ad2eb3C8C24DB87,Gill-Lamb,http://lin.com/,Cote d'Ivoire,Programmable intermediate conglomeration,2005,Apparel / Fashion,5105
+4,D76BB12E5eE165B,Bauer-Weiss,https://gillespie-stout.com/,United States of America,Synergistic maximized definition,2015,Dairy,9069
+5,2F31EddF2Db9aAE,Love-Palmer,https://kramer.com/,Denmark,Optimized optimizing moderator,2010,Management Consulting,6991
+6,6774DC1dB00BD11,"Farmer, Edwards and Andrade",http://wolfe-boyd.com/,Norfolk Island,Virtual leadingedge benchmark,2003,Mental Health Care,3503
+7,116B5cD4eE1fAAc,"Bass, Hester and Mcclain",https://meza-smith.com/,Uzbekistan,Multi-tiered system-worthy hub,1994,Computer Hardware,2762
+8,AB2eA15d98b6BD4,"Strickland, Gray and Jensen",http://kerr.info/,Israel,Team-oriented fresh-thinking knowledge user,1987,Performing Arts,7020
+9,0c6D831e8DceCfE,"Sparks, Decker and Powell",https://www.howe.net/,Israel,Down-sized content-based info-mediaries,1977,Marketing / Advertising / Sales,2709
+10,9ABE0c8aee135d6,"Osborn, Ford and Macdonald",http://www.mcdonald-watts.biz/,Syrian Arab Republic,Optional coherent focus group,1990,Investment Banking / Venture,5731
+11,C494aBe0CDB9c70,Gonzales Inc,http://lara.org/,Angola,Enterprise-wide attitude-oriented conglomeration,2019,Capital Markets / Hedge Fund / Private Equity,2252
+12,9FBF69aa2D9AAF1,"Ballard, Goodman and Boone",http://berger-chen.info/,Iran,Multi-layered zero administration ability,2019,Logistics / Procurement,6165
+13,4EB9d3E5cF79b91,"Bernard, Payne and Spencer",http://williamson.net/,Afghanistan,Polarized dynamic projection,1990,Transportation,730
+14,e5CA6529DCD4030,Mcpherson-Blanchard,http://www.ward.com/,Bulgaria,Integrated didactic product,1972,Law Enforcement,9890
+15,b0BBeBB36bAbb35,"Koch, Gomez and Hays",http://ewing-rosario.biz/,French Southern Territories,Operative national superstructure,1997,Financial Services,8497


### PR DESCRIPTION
## Changes
- LLM returns a JSON "plan" containing "steps". 
-  Steps can either be of type "dask" or "primitive"
- Example LLM output:
```python
[
        {{
            "type": "primitive",
            "operation": "Map",
            "params": {{
                "subprompt": "Extract category and sub-category from industry",
                "input_fields": ["Industry"],
                "output_fields": ["Category","Sub-Category"]
            }},
        }},
        {{
            "type": "primitive",
            "operation": "Filter",
            "params": {{
                "subprompt": "Keep only organizations in Africa",
                "input_fields": ["Country"]
            }},
        }},
        {{
            "type": "dask",
            "operation": "add_column",
            "params": {{
            "new_column": "Year",
            "expression": "df['Date'].dt.year"
            }}
        }},
        {{
            "type": "dask",
            "operation": "group_by_agg",
            "params": {{
            "group_columns": ["Year", "Month"],
            "aggregations": {{'Gross Amount':'sum'}}
            }}
        }}
        ]
```
Steps are plugged into a code template and executed in series.


