### PR TITLE
Improved optimized_batch_completion

### DIFF
--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -63,9 +63,9 @@ def llm_batch_inference(
     prompt = f"FILTERING CRITERIA:{os.linesep}{prompt}{os.linesep}{os.linesep}"
     suffix = (
         f"{os.linesep}{os.linesep}"
-        f"DECISION:Your response MUST be the entire input record as  Python dictionary in the format: index=<row_index>|{{key1: value1, key2: value2, ...}}<endofrow> with added key called '__filter__' with value either True to KEEP the record or False to REMOVE it."
-        f"No explanations or additional text."
-        f"ALWAYS STICK TO THE FORMAT index=<row_index>|{{key1: value1, key2: value2, ...}}<endofrow> with added key called '__filter__' with value either True to KEEP the record or False to REMOVE it."
+        "DECISION:Your response MUST be the entire input record as  Python dictionary in the format: index=<row_index>|{{key1: value1, key2: value2, ...}}<endofrow> with added key called '__filter__' with value either True to KEEP the record or False to REMOVE it."
+        "No explanations or additional text."
+        "ALWAYS STICK TO THE FORMAT index=<row_index>|{{key1: value1, key2: value2, ...}}<endofrow> with added key called '__filter__' with value either True to KEEP the record or False to REMOVE it."
     )
     df[llm_output_column] = llm(df[serialized_input_column], prefix, prompt, suffix, optimized=True)
     return df

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -67,11 +67,10 @@ def llm_batch_inference(
 
     suffix = (
         f"{os.linesep}{os.linesep}"
-        f"""Your response MUST be the entire input record as a valid Python dictionary in the format
-         'index=<row_index>|{{key1: value1, key2: value2, ...}}'  with added keys of expected new fields if any.
-        ALWAYS START YOUR RESPONSE WITH 'index=<row_index>|' WHERE <row_index> IS THE INDEX OF THE ROW.
-        ALWAYS END YOUR RESPONSE WITH '<endofrow>'.
-        """
+        "Your response MUST be the entire input record as a valid Python dictionary in the format"
+        "'index=<row_index>|{{key1: value1, key2: value2, ...}}'  with added keys of expected new fields if any."
+         
+        "ALWAYS START YOUR RESPONSE WITH 'index=<row_index>|' WHERE <row_index> IS THE INDEX OF THE ROW."
     )
 
     df[llm_output_column] = llm(df[serialized_input_column], prefix, prompt, suffix, optimized=True)

--- a/datatune/llm/llm.py
+++ b/datatune/llm/llm.py
@@ -53,7 +53,7 @@ class LLM:
     def _create_batched_prompts(
         self,
         input_rows: List[str],
-        batch_prefix: str,
+        user_batch_prefix: str,
         prompt_per_row: str,
         batch_suffix: str,
     ) -> List[str]:
@@ -74,14 +74,41 @@ class LLM:
 
         """
         batch_prefix = (
-        "You will be given requests in the format 'index=<index>|{prompt}'. Each request ends with '<endofrow>'.\n"
-        "Respond to each prompt in order.\n"
-        "Each answer must be formatted exactly as 'index=<index>|{answer}<endofrow>'.\n"
-        "{answer} MUST BE ENCLOSED IN CURLY BRACES with strings in quotes.\n"
-        "DO NOT skip or omit any rows. DO NOT add explanations, backticks, or extra text.\n"
-        "Always start with 'index=<index>|' and end with '<endofrow>'.\n"
-        f"Instructions:\n{batch_prefix or ''}"
+            "You will receive multiple prompts in the format:\n"
+            "index=<index>|{prompt}\n"
+            "Each prompt ends with '<endofrow>'.\n\n"
+
+            "You must reply to each prompt in the exact same order using this format:\n"
+            "index=<index>|{answer}<endofrow>\n\n"
+
+            "Formatting Rules (must always be followed):\n"
+            "1. Each response must begin with 'index=<index>|' and end with '<endofrow>'.\n"
+            "2. The {answer} must be a valid Python object (e.g., list, dict, string, number, tuple, bool, or None).\n"
+            "3. The entire Python object must be enclosed in curly braces `{}`.\n"
+            "4. All strings must use double quotes — not single quotes.\n"
+            "5. Do not include any markdown, explanations, or text outside the required format.\n"
+            "6. Return exactly one object per prompt.\n"
+            "7. If a prompt asks for a string, wrap it in quotes inside the curly braces.\n\n"
+
+            f"formatting rules:\n{user_batch_prefix}\n\n"
+
+            "Examples:\n"
+            "- If the prompt says 'return a Python list of names':\n"
+            "  index=0|{\"Alice\", \"Bob\", \"Charlie\"}<endofrow>\n"
+            "- If the prompt says 'return a Python dictionary':\n"
+            "  index=0|{{\"key1\": \"value1\", \"key2\": \"value2\"}}<endofrow>\n"
+            "- If the prompt says 'return a string':\n"
+            "  index=0|{{\"This is a string.\"}}<endofrow>\n"
+            "- If the prompt says 'return an integer':\n"
+            "  index=0|{42}<endofrow>\n"
+            "- If the prompt says 'return a boolean':\n"
+            "  index=0|{True}<endofrow>\n"
+            "- If the prompt says 'return a tuple':\n"
+            "  index=0|{(1, 2, 3)}<endofrow>\n\n"
+
+            "Strictly follow this schema. Never include extra text or formatting."
         )
+
 
 
         max_tokens = self.get_max_tokens()

--- a/datatune/logger.py
+++ b/datatune/logger.py
@@ -1,4 +1,7 @@
 import logging
+import threading
+import time
+import sys
 
 
 def get_logger(name: str = None):
@@ -15,3 +18,28 @@ def get_logger(name: str = None):
         logger.setLevel(logging.INFO)
 
     return logger
+class Spinner:
+    def __init__(self, message="Processing..."):
+        self.message = message
+        self.spinner = ['|', '/', '-', '\\']
+        self.running = False
+        self.thread = None
+
+    def start(self):
+        self.running = True
+        self.thread = threading.Thread(target=self._spin)
+        self.thread.start()
+
+    def _spin(self):
+        i = 0
+        while self.running:
+            sys.stdout.write(f"\r{self.message} {self.spinner[i % len(self.spinner)]}")
+            sys.stdout.flush()
+            i += 1
+            time.sleep(0.1)
+        sys.stdout.write("\r" + " " * (len(self.message) + 2) + "\r")
+
+    def stop(self):
+        self.running = False
+        if self.thread is not None:
+            self.thread.join()

--- a/datatune/logger.py
+++ b/datatune/logger.py
@@ -4,12 +4,27 @@ import time
 import sys
 
 
+class ColorFormatter(logging.Formatter):
+    COLORS = {
+        "DEBUG": "\033[37m",   # white
+        "INFO": "\033[36m",    # cyan
+        "WARNING": "\033[33m", # yellow
+        "ERROR": "\033[31m",   # red
+        "CRITICAL": "\033[41m",# red background
+    }
+    RESET = "\033[0m"
+
+    def format(self, record):
+        color = self.COLORS.get(record.levelname, self.RESET)
+        record.levelname = f"{color}{record.levelname}{self.RESET}"
+        return super().format(record)
+
 def get_logger(name: str = None):
     logger = logging.getLogger(name)
 
     if not logger.hasHandlers():
         handler = logging.StreamHandler()
-        formatter = logging.Formatter(
+        formatter = ColorFormatter(
             fmt="%(asctime)s | %(levelname)-8s | %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )


### PR DESCRIPTION
LLM will now return responses for batches in the format `index=<index>|{<requested_python_literal>}<endofrow>`
- eg: 
- `index=<index>|{['item1','item2']}<endofrow>`
- `index=<index>|{"this is a string"}<endofrow>`





