### PR TITLE
Ibis lazy pipeline

### DIFF
--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -25,11 +25,16 @@ def filter(*, prompt, input_fields=None):
         elif _is_ibis_table(data):
             from .ibis.filter_ibis import _filter_ibis
             from .ibis.lazy_pipeline import LazyTable, FilterNode
+
             filter_obj = _filter_ibis(
                 prompt=prompt,
-                input_fields=input_fields,
+                input_fields=input_fields
             )
             filter_obj.llm = llm
+
+            if not isinstance(data, LazyTable):
+                data = LazyTable(data)
+
             return LazyTable(FilterNode(filter_obj, data))
         raise TypeError(f"Unsupported data type: {type(data)}")
 

--- a/datatune/core/filter.py
+++ b/datatune/core/filter.py
@@ -1,7 +1,8 @@
 def _is_ibis_table(obj):
     try:
         import ibis
-        return isinstance(obj, ibis.Table)
+        from .ibis.lazy_pipeline import LazyTable
+        return isinstance(obj, (ibis.Table, LazyTable))
     except ImportError:
         return False
     
@@ -23,10 +24,13 @@ def filter(*, prompt, input_fields=None):
             )(llm, data)
         elif _is_ibis_table(data):
             from .ibis.filter_ibis import _filter_ibis
-            return _filter_ibis(
+            from .ibis.lazy_pipeline import LazyTable, FilterNode
+            filter_obj = _filter_ibis(
                 prompt=prompt,
                 input_fields=input_fields,
-            )(llm, data)
+            )
+            filter_obj.llm = llm
+            return LazyTable(FilterNode(filter_obj, data))
         raise TypeError(f"Unsupported data type: {type(data)}")
 
     return apply

--- a/datatune/core/ibis/filter_ibis.py
+++ b/datatune/core/ibis/filter_ibis.py
@@ -104,14 +104,14 @@ class _filter_ibis:
         self.llm = llm
         if self.input_fields:
             missing = [f for f in self.input_fields if f not in table.columns]
-        if missing:
-            error_msg = (
-                f"[datatune] Schema mismatch: The following input_fields were not found: {missing}. "
-                f"Available columns: {list(table.columns)}"
-            )
-            logger.error(error_msg)
+            if missing:
+                error_msg = (
+                    f"[datatune] Schema mismatch: The following input_fields were not found: {missing}. "
+                    f"Available columns: {list(table.columns)}"
+                )
+                logger.error(error_msg)
             
-            raise ValueError(error_msg)
+                raise ValueError(error_msg)
 
         table = add_serialized_col(
             table, 

--- a/datatune/core/ibis/lazy_pipeline.py
+++ b/datatune/core/ibis/lazy_pipeline.py
@@ -1,0 +1,49 @@
+class LazyTable:
+
+    def __init__(self, plan):
+        self.plan = plan
+    
+    def execute(self):
+        if isinstance(self.plan, PlanNode):
+            return self.plan.execute()
+        else:
+            return self.plan
+        
+    def show_plan(self):
+        return repr(self.plan)
+    
+class PlanNode:
+
+    def execute(self):
+        raise NotImplementedError("Subclasses must implement execute()")
+    
+class MapNode(PlanNode):
+
+    def __init__(self, map_obj, source):
+        self.map_obj = map_obj
+        self.source = source
+
+    def execute(self):
+        if isinstance(self.source, LazyTable):
+            table = self.source.execute()
+        else:
+            table = self.source 
+
+        return self.map_obj(self.map_obj.llm, table)
+    
+class FilterNode(PlanNode):
+    def __init__(self, filter_obj, source):
+        self.filter_obj = filter_obj
+        self.source = source
+
+    def execute(self):
+        if isinstance(self.source, LazyTable):
+            table = self.source.execute()
+        else:
+            table = self.source 
+
+        return self.filter_obj(self.filter_obj.llm, table)
+
+
+
+    

--- a/datatune/core/ibis/map_ibis.py
+++ b/datatune/core/ibis/map_ibis.py
@@ -124,14 +124,14 @@ class _map_ibis:
         self.llm = llm
         if self.input_fields:
             missing = [f for f in self.input_fields if f not in table.columns]
-        if missing:
-            error_msg = (
-                f"[datatune] Schema mismatch: The following input_fields were not found: {missing}. "
-                f"Available columns: {list(table.columns)}"
-            )
-            logger.error(error_msg)
+            if missing:
+                error_msg = (
+                    f"[datatune] Schema mismatch: The following input_fields were not found: {missing}. "
+                    f"Available columns: {list(table.columns)}"
+                )
+                logger.error(error_msg)
             
-            raise ValueError(error_msg)
+                raise ValueError(error_msg)
 
 
         table = add_serialized_col(

--- a/datatune/core/map.py
+++ b/datatune/core/map.py
@@ -27,12 +27,17 @@ def map(*, prompt, output_fields, input_fields=None):
         elif _is_ibis_table(data):
             from .ibis.map_ibis import _map_ibis
             from .ibis.lazy_pipeline import LazyTable, MapNode
+
             map_obj = _map_ibis(
                 prompt=prompt,
                 output_fields=output_fields,
                 input_fields=input_fields,
             )
             map_obj.llm = llm
+
+            if not isinstance(data, LazyTable):
+                data = LazyTable(data)
+
             return LazyTable(MapNode(map_obj, data))
 
         raise TypeError(f"Unsupported data type: {type(data)}")


### PR DESCRIPTION
# Lazy execution for Ibis tables

- `dt.map` and `dt.filter` on ibis tables is now lazy (like dask tables)
- Transformations run in sequence after calling `execute()`
```python
filtered = dt.filter(
    prompt = "filter out records where industry is not finance related",
    input_fields=["Industry"] 
)(llm, table)    # pass ibis table

mapped = dt.map(
    prompt = "create column called sub category based on the industry column",
    output_fields=["sub_category"],
    input_fields=["Industry"]
)(llm, filtered)

filtered = dt.filter(
    prompt = "keep only organizations that are in africa",
    input_fields=["Country"] 
)(llm, mapped)
result = filtered.execute()
```
`filtered`  and `mapped` are `LazyTable` objects. Calling `.execute()` on a `LazyTable` object will execute all the chained transformations it depends on.
`result` is a `pandas.DataFrame`